### PR TITLE
docs: don't print plan JSON in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,8 @@ Assuming you [downloaded Infracost](https://www.infracost.io/docs/#quick-start) 
 
           - name: Terraform show
             id: tf_show
-            run: terraform show -json plan.tfplan
+            run: terraform show -json plan.tfplan > plan.json
             working-directory: path/to/my-terraform
-
-          - name: Save Terraform Plan JSON
-            run: echo '${{ steps.tf_show.outputs.stdout }}' > plan.json # Do not change
 
           - name: Setup Infracost
             uses: infracost/actions/setup@master


### PR DESCRIPTION
This updates the example to not print the plan JSON. Since we're using `terraform_wrapper: false` with the setup Terraform action writing this directly to the file works. Without `terraform_wrapper: false` this would not write a valid JSON file.