### PR TITLE
Fix/comment actions

### DIFF
--- a/.github/workflows/comment_test.yml
+++ b/.github/workflows/comment_test.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           path: ./testdata/comment/simple_breakdown.json
           tag: "infracost-pull-request"
+          behavior: new
   test_commit:
     name: Test Commit Comment
     runs-on: ubuntu-latest
@@ -45,3 +46,4 @@ jobs:
           path: "./testdata/comment/*.json"
           target-type: commit
           tag: "infracost-commit"
+          behavior: new

--- a/.github/workflows/comment_test.yml
+++ b/.github/workflows/comment_test.yml
@@ -28,6 +28,7 @@ jobs:
         uses: ./comment
         with:
           path: ./testdata/comment/simple_breakdown.json
+          tag: "infracost-pull-request"
   test_commit:
     name: Test Commit Comment
     runs-on: ubuntu-latest
@@ -41,5 +42,6 @@ jobs:
       - name: Infracost comment
         uses: ./comment
         with:
-          path: '["./testdata/comment/simple_breakdown.json", "./testdata/comment/simple_breakdown.json"]'
+          path: "./testdata/comment/*.json"
           target-type: commit
+          tag: "infracost-commit"

--- a/.github/workflows/examples_test.yml
+++ b/.github/workflows/examples_test.yml
@@ -31,15 +31,19 @@ jobs:
           DEV_AWS_SECRET_ACCESS_KEY: ${{ secrets.EXAMPLE_DEV_AWS_SECRET_ACCESS_KEY }}
           PROD_AWS_ACCESS_KEY_ID: ${{ secrets.EXAMPLE_PROD_AWS_ACCESS_KEY_ID }}
           PROD_AWS_SECRET_ACCESS_KEY: ${{ secrets.EXAMPLE_PROD_AWS_SECRET_ACCESS_KEY }}
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: >-
-          diff ./testdata/multi-project-config-file_comment_golden.md
-          /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: >-
+          diff -y ./testdata/multi-project-config-file_comment_golden.md
+          infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: >-
           cp /tmp/infracost_comment.md
@@ -95,20 +99,19 @@ jobs:
         uses: ./setup
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
-      - name: Combine the results
-        run: >
-          infracost output --path="/tmp/infracost_jsons/*.json" --format=json
-          --out-file=/tmp/infracost_combined.json
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost_combined.json
-          --format=github-comment --show-skipped
-          --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: >-
-          diff ./testdata/multi-project-matrix-merge_comment_golden.md
-          /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path "/tmp/infracost_jsons/*.json" \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: >-
+          diff -y ./testdata/multi-project-matrix-merge_comment_golden.md
+          infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: >-
           cp /tmp/infracost_comment.md
@@ -138,16 +141,20 @@ jobs:
           DEV_AWS_SECRET_ACCESS_KEY: ${{ secrets.EXAMPLE_DEV_AWS_SECRET_ACCESS_KEY }}
           PROD_AWS_ACCESS_KEY_ID: ${{ secrets.EXAMPLE_PROD_AWS_ACCESS_KEY_ID }}
           PROD_AWS_SECRET_ACCESS_KEY: ${{ secrets.EXAMPLE_PROD_AWS_SECRET_ACCESS_KEY }}
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: >-
-          diff
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: >-
+          diff -y
           ./testdata/multi-terraform-workspace-config-file_comment_golden.md
-          /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+          infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: >-
           cp /tmp/infracost_comment.md
@@ -180,15 +187,19 @@ jobs:
         run: >-
           infracost breakdown --path=examples/private-terraform-module/code
           --format=json --out-file=/tmp/infracost.json
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: >-
-          diff ./testdata/private-terraform-module_comment_golden.md
-          /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: >-
+          diff -y ./testdata/private-terraform-module_comment_golden.md
+          infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: >-
           cp /tmp/infracost_comment.md
@@ -243,13 +254,17 @@ jobs:
         run: >-
           infracost breakdown --path=examples/slack/code/plan.json --format json
           --out-file /tmp/infracost.json
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: diff ./testdata/slack_comment_golden.md /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: diff -y ./testdata/slack_comment_golden.md infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: cp /tmp/infracost_comment.md ./testdata/slack_comment_golden.md
         if: env.UPDATE_GOLDEN_FILES == 'true'
@@ -295,15 +310,19 @@ jobs:
           --format=json --out-file=/tmp/infracost.json
         env:
           INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TFC_TOKEN }}
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: >-
-          diff ./testdata/terraform-cloud-enterprise_comment_golden.md
-          /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: >-
+          diff -y ./testdata/terraform-cloud-enterprise_comment_golden.md
+          infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: >-
           cp /tmp/infracost_comment.md
@@ -326,15 +345,19 @@ jobs:
         run: >-
           infracost breakdown --path=examples/terraform-directory/code
           --format=json --out-file=/tmp/infracost.json
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: >-
-          diff ./testdata/terraform-directory_comment_golden.md
-          /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: >-
+          diff -y ./testdata/terraform-directory_comment_golden.md
+          infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: >-
           cp /tmp/infracost_comment.md
@@ -353,15 +376,19 @@ jobs:
         run: >-
           infracost breakdown --path=examples/terraform-plan-json/code/plan.json
           --format=json --out-file=/tmp/infracost.json
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: >-
-          diff ./testdata/terraform-plan-json_comment_golden.md
-          /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: >-
+          diff -y ./testdata/terraform-plan-json_comment_golden.md
+          infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: >-
           cp /tmp/infracost_comment.md
@@ -388,13 +415,17 @@ jobs:
         run: >-
           infracost breakdown --path=examples/terragrunt/code --format=json
           --out-file=/tmp/infracost.json
-      - name: Generate Infracost comment
-        run: >-
-          infracost output --path=/tmp/infracost.json --format=github-comment
-          --show-skipped --out-file=/tmp/infracost_comment.md
-      - name: Check the comment
-        run: diff ./testdata/terragrunt_comment_golden.md /tmp/infracost_comment.md
-        if: env.UPDATE_GOLDEN_FILES != 'true'
+      - name: Post Infracost comment
+        run: |-
+          infracost comment github --path /tmp/infracost.json \
+          --repo $GITHUB_REPOSITORY \
+          --github-token ${{github.token}} \
+          --pull-request ${{github.event.pull_request.number}} \
+          --behavior update \
+          --dry-run true \
+          > infracost-comment.md
+      - run: diff -y ./testdata/terragrunt_comment_golden.md infracost-comment.md
+        name: Check the comment
       - name: Update the golden comment file
         run: cp /tmp/infracost_comment.md ./testdata/terragrunt_comment_golden.md
         if: env.UPDATE_GOLDEN_FILES == 'true'

--- a/.github/workflows/get_comment_test.yml
+++ b/.github/workflows/get_comment_test.yml
@@ -25,30 +25,36 @@ jobs:
         with:
           api-key: abcdefg123456
 
+      - name: Save comment output
+        run: |
+          infracost comment github --path ./testdata/comment/simple_breakdown.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior new \
+                                   --dry-run true \
+                                   > expected.md
+
+          head -n -2 expected.md > tmp.txt && mv tmp.txt expected.md
+
       - name: Infracost comment
         id: post-comment
         uses: ./comment
         with:
           path: ./testdata/comment/simple_breakdown.json
+          tag: "custom-tag"
+          behavior: new
 
       - name: Infracost get comment
         id: get-comment
         uses: ./get-comment
+        with:
+          tag: "custom-tag"
 
-      - name: Check comment
-        shell: bash
-        run: |
-          expected=$(cat <<\EOF
-          ${{ steps.post-comment.outputs.body }}
-          EOF
-          )
+      - run: |
           actual=$(cat <<\EOF
           ${{ steps.get-comment.outputs.body }}
           EOF
           )
-
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::Expected comment '$expected' got '$actual'"
-            exit 1
-          fi
-
+          diff -y <(echo "$actual") expected.md
+        name: Check the comment

--- a/README.md
+++ b/README.md
@@ -76,17 +76,23 @@ The following steps assume a simple Terraform directory is being used, we recomm
             # env:
             #   MY_ENV: ${{ secrets.MY_ENV }}
 
-          # See https://github.com/infracost/actions/tree/master/comment
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
           # for other inputs such as target-type.
           - name: Post Infracost comment
-            uses: infracost/actions/comment@v1
-            with:
-              path: /tmp/infracost.json
-              # Choose the commenting behavior, 'update' is a good default:
-              behavior: update # Create a single comment and update it. The "quietest" option.                 
-              # behavior: delete-and-new # Delete previous comments and create a new one.
-              # behavior: hide-and-new # Minimize previous comments and create a new one.
-              # behavior: new # Create a new cost estimate comment on every push.
+            run: |
+
+              # Posts a comment to the PR using the 'update' behavior.
+              # This creates a single comment and updates it. The "quietest" option.
+              # The other valid behaviors are:
+              #   delete-and-new - Delete previous comments and create a new one.
+              #   hide-and-new - Minimize previous comments and create a new one.
+              #   new - Create a new cost estimate comment on every push.
+
+              infracost comment github --path /tmp/infracost.json \
+                                       --repo $GITHUB_REPOSITORY \
+                                       --github-token ${{github.token}} \
+                                       --pull-request ${{github.event.pull_request.number}} \
+                                       --behavior update
     ```
 
 4. 🎉 That's it! Send a new pull request to change something in Terraform that costs money. You should see a pull request comment that gets updated, e.g. the 📉 and 📈 emojis will update as changes are pushed!
@@ -118,8 +124,10 @@ If you use HashiCorp Sentinel, follow [our example](examples/sentinel) to output
 
 We recommend you use the above [quick start](#quick-start) guide and examples, which combine the following individual actions:
 - [setup](setup): downloads and installs the Infracost CLI in your GitHub Actions workflow.
-- [comment](comment): adds comments to pull requests.
-- [get-comment](get-comment): reads a comment from a pull request.
+
+### Deprecated Actions
+- [comment](comment): adds comments to pull requests. This action is deprecated, please use `infracost comment` directly.
+- [get-comment](get-comment): reads a comment from a pull request. This action is deprecated.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -76,18 +76,15 @@ The following steps assume a simple Terraform directory is being used, we recomm
             # env:
             #   MY_ENV: ${{ secrets.MY_ENV }}
 
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           - name: Post Infracost comment
             run: |
-
               # Posts a comment to the PR using the 'update' behavior.
               # This creates a single comment and updates it. The "quietest" option.
               # The other valid behaviors are:
               #   delete-and-new - Delete previous comments and create a new one.
               #   hide-and-new - Minimize previous comments and create a new one.
               #   new - Create a new cost estimate comment on every push.
-
               infracost comment github --path /tmp/infracost.json \
                                        --repo $GITHUB_REPOSITORY \
                                        --github-token ${{github.token}} \

--- a/comment/action.yml
+++ b/comment/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Post infracost comment to a github pull-request
+    - name: Post a Infracost comment to a GitHub pull request
       if: ${{ (inputs.target-type != 'commit') && (github.event.pull_request.number != '') }}
       shell: bash
       run: |
@@ -32,7 +32,7 @@ runs:
                                  --pull-request ${{github.event.pull_request.number}} \
                                  --behavior ${{inputs.behavior}}
 
-    - name: Post infracost comment to a commit sha
+    - name: Post a Infracost comment to a commit SHA
       if: ${{ (inputs.target-type == 'commit') }}
       shell: bash
       run: |

--- a/comment/action.yml
+++ b/comment/action.yml
@@ -18,48 +18,27 @@ inputs:
     description: 'Default to {{ github.token }}. This is the default GitHub token available to actions and is used to post comments. The default token permissions (https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions) work fine; `pull-requests: write` is required if you need to customize these.'
     default: '${{ github.token }}'
     required: false
-outputs:
-  body:
-    description: 'The body of comment that was posted.'
-    value: ${{ steps.compost-comment.outputs.body }}
 runs:
   using: "composite"
   steps:
-    - name: Run infracost output
+    - name: Post infracost comment to a github pull-request
+      if: ${{ (inputs.target-type != 'commit') && (github.event.pull_request.number != '') }}
       shell: bash
-
       run: |
-        # handle multiple paths
-        if jq . >/dev/null 2>&1 <<< '${{ inputs.path }}'; then
-          paths=$(jq -r 'if type == "array" then map("--path " + .) | join(" ") else . end' <<< '${{ inputs.path }}')
-        else
-          paths="--path ${{ inputs.path }}"
-        fi
-        echo "::notice::Using paths: $paths"
+        infracost comment github --path ${{inputs.path}} \
+                                 --repo $GITHUB_REPOSITORY \
+                                 --tag "${{inputs.tag}}" \
+                                 --github-token ${{inputs.github-token}} \
+                                 --pull-request ${{github.event.pull_request.number}} \
+                                 --behavior ${{inputs.behavior}}
 
-        export INFRACOST_CI_POST_CONDITION=${{ inputs.behavior }}
-
-        infracost output $paths --format github-comment --show-skipped --out-file comment.md
-
-        if [ "${{ inputs.target-type }}" != "commit" ]; then
-          if [ "${{ inputs.behavior }}" = "update" ]; then
-            printf "\nThis comment will be updated when the cost estimate changes.\n\n" >> comment.md
-          elif [ "${{ inputs.behavior }}" = "delete-and-new" ]; then
-            printf "\nThis comment will be replaced when the cost estimate changes.\n\n" >> comment.md
-          fi
-        fi
-
-        printf "<sub>\n" >> comment.md
-        printf "  Is this comment useful? <a href=\"https://www.infracost.io/feedback/submit/?value=yes\" rel=\"noopener noreferrer\" target=\"_blank\">Yes</a>, <a href=\"https://www.infracost.io/feedback/submit/?value=no\" rel=\"noopener noreferrer\" target=\"_blank\">No</a>\n" >> comment.md
-        printf "</sub>\n" >> comment.md
-    - name: Comment
-      id: compost-comment
-      uses: infracost/compost-action@master
-      with:
-        body-file: comment.md
-        behavior: ${{ inputs.behavior }}
-        target-type: ${{ inputs.target-type }}
-        tag: ${{ inputs.tag }}
-        github-token: ${{ inputs.github-token }}
-
-
+    - name: Post infracost comment to a commit sha
+      if: ${{ (inputs.target-type == 'commit') }}
+      shell: bash
+      run: |
+        infracost comment github --path ${{inputs.path}} \
+                                 --repo $GITHUB_REPOSITORY \
+                                 --tag "${{inputs.tag}}" \
+                                 --github-token ${{inputs.github-token}} \
+                                 --commit $GITHUB_SHA \
+                                 --behavior ${{inputs.behavior}}

--- a/examples/multi-project/README.md
+++ b/examples/multi-project/README.md
@@ -38,17 +38,30 @@ jobs:
           PROD_AWS_ACCESS_KEY_ID: ${{ secrets.EXAMPLE_PROD_AWS_ACCESS_KEY_ID }}
           PROD_AWS_SECRET_ACCESS_KEY: ${{ secrets.EXAMPLE_PROD_AWS_SECRET_ACCESS_KEY }}
 
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)
 
 ## Using GitHub Actions build matrix 
 
-This example shows how to run Infracost actions with multiple Terraform projects using a GitHub Actions build matrix. The first job uses a build matrix to generate multiple Infracost output JSON files and upload them as artifacts. The second job downloads these JSON files, combines them using `infracost output`, and posts a comment.
+This example shows how to run Infracost actions with multiple Terraform projects using a GitHub Actions build matrix. The first job uses a build matrix to generate multiple Infracost output JSON files and upload them as artifacts. The second job downloads these JSON files and posts a combined comment to the PR using `infracost comment` glob support.
 
 [//]: <> (BEGIN EXAMPLE)
 ```yml
@@ -115,14 +128,23 @@ jobs:
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
           
-      - name: Combine the results
+      - name: Post Infracost comment
         run: |
-          infracost output --path="/tmp/infracost_jsons/*.json" --format=json --out-file=/tmp/infracost_combined.json
-          
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost_combined.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path "/tmp/infracost_jsons/*.json" \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/multi-project/README.md
+++ b/examples/multi-project/README.md
@@ -40,17 +40,13 @@ jobs:
 
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \
@@ -130,17 +126,13 @@ jobs:
           
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path "/tmp/infracost_jsons/*.json" \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/multi-terraform-workspace/README.md
+++ b/examples/multi-terraform-workspace/README.md
@@ -36,17 +36,13 @@ jobs:
 
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/multi-terraform-workspace/README.md
+++ b/examples/multi-terraform-workspace/README.md
@@ -34,10 +34,23 @@ jobs:
           PROD_AWS_ACCESS_KEY_ID: ${{ secrets.EXAMPLE_PROD_AWS_ACCESS_KEY_ID }}
           PROD_AWS_SECRET_ACCESS_KEY: ${{ secrets.EXAMPLE_PROD_AWS_SECRET_ACCESS_KEY }}
 
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/private-terraform-module/README.md
+++ b/examples/private-terraform-module/README.md
@@ -37,10 +37,23 @@ jobs:
       - name: Run Infracost
         run: infracost breakdown --path=examples/private-terraform-module/code --format=json --out-file=/tmp/infracost.json
 
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/private-terraform-module/README.md
+++ b/examples/private-terraform-module/README.md
@@ -39,17 +39,13 @@ jobs:
 
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -31,17 +31,13 @@ jobs:
 
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -29,11 +29,24 @@ jobs:
       - name: Generate Infracost JSON
         run: infracost breakdown --path=examples/slack/code/plan.json --format json --out-file /tmp/infracost.json
 
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 
       - name: Generate Slack message
         id: infracost-slack

--- a/examples/terraform-cloud-enterprise/README.md
+++ b/examples/terraform-cloud-enterprise/README.md
@@ -38,17 +38,13 @@ jobs:
         
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/terraform-cloud-enterprise/README.md
+++ b/examples/terraform-cloud-enterprise/README.md
@@ -36,10 +36,23 @@ jobs:
           INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TFC_TOKEN }} 
           # INFRACOST_TERRAFORM_CLOUD_HOST: my-tfe-host.com # For Terraform Enterprise users only.
         
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-directory/README.md
+++ b/examples/terraform-directory/README.md
@@ -30,10 +30,23 @@ jobs:
       - name: Run Infracost
         run: infracost breakdown --path=examples/terraform-directory/code --format=json --out-file=/tmp/infracost.json
         
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-directory/README.md
+++ b/examples/terraform-directory/README.md
@@ -32,17 +32,13 @@ jobs:
         
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/terraform-plan-json/README.md
+++ b/examples/terraform-plan-json/README.md
@@ -23,10 +23,23 @@ jobs:
       - name: Run Infracost
         run: infracost breakdown --path=examples/terraform-plan-json/code/plan.json --format=json --out-file=/tmp/infracost.json
         
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-plan-json/README.md
+++ b/examples/terraform-plan-json/README.md
@@ -25,17 +25,13 @@ jobs:
         
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/terragrunt/README.md
+++ b/examples/terragrunt/README.md
@@ -37,17 +37,13 @@ jobs:
         
       - name: Post Infracost comment
         run: |
-
           # Posts a comment to the PR using the 'update' behavior.
           # This creates a single comment and updates it. The "quietest" option.
           # The other valid behaviors are:
           #   delete-and-new - Delete previous comments and create a new one.
           #   hide-and-new - Minimize previous comments and create a new one.
           #   new - Create a new cost estimate comment on every push.
-          #
-          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
-          # for other inputs such as target-type.
-
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
           infracost comment github --path /tmp/infracost.json \
                                    --repo $GITHUB_REPOSITORY \
                                    --github-token ${{github.token}} \

--- a/examples/terragrunt/README.md
+++ b/examples/terragrunt/README.md
@@ -35,10 +35,23 @@ jobs:
       - name: Run Infracost
         run: infracost breakdown --path=examples/terragrunt/code --format=json --out-file=/tmp/infracost.json
         
-      - name: Post the comment
-        uses: infracost/actions/comment@v1
-        with:
-          path: /tmp/infracost.json
-          behavior: update # Create a single comment and update it. See https://github.com/infracost/actions/tree/master/comment for other options
+      - name: Post Infracost comment
+        run: |
+
+          # Posts a comment to the PR using the 'update' behavior.
+          # This creates a single comment and updates it. The "quietest" option.
+          # The other valid behaviors are:
+          #   delete-and-new - Delete previous comments and create a new one.
+          #   hide-and-new - Minimize previous comments and create a new one.
+          #   new - Create a new cost estimate comment on every push.
+          #
+          # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests
+          # for other inputs such as target-type.
+
+          infracost comment github --path /tmp/infracost.json \
+                                   --repo $GITHUB_REPOSITORY \
+                                   --github-token ${{github.token}} \
+                                   --pull-request ${{github.event.pull_request.number}} \
+                                   --behavior update
 ```
 [//]: <> (END EXAMPLE)

--- a/testdata/multi-project-config-file_comment_golden.md
+++ b/testdata/multi-project-config-file_comment_golden.md
@@ -111,3 +111,11 @@ Key: ~ changed, + added, - removed
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/multi-project-matrix-merge_comment_golden.md
+++ b/testdata/multi-project-matrix-merge_comment_golden.md
@@ -111,3 +111,11 @@ Key: ~ changed, + added, - removed
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/multi-terraform-workspace-config-file_comment_golden.md
+++ b/testdata/multi-terraform-workspace-config-file_comment_golden.md
@@ -111,3 +111,11 @@ Key: ~ changed, + added, - removed
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/private-terraform-module_comment_golden.md
+++ b/testdata/private-terraform-module_comment_golden.md
@@ -47,3 +47,11 @@ Key: ~ changed, + added, - removed
 ∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/slack_comment_golden.md
+++ b/testdata/slack_comment_golden.md
@@ -63,3 +63,11 @@ Key: ~ changed, + added, - removed
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/terraform-cloud-enterprise_comment_golden.md
+++ b/testdata/terraform-cloud-enterprise_comment_golden.md
@@ -63,3 +63,11 @@ Key: ~ changed, + added, - removed
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/terraform-directory_comment_golden.md
+++ b/testdata/terraform-directory_comment_golden.md
@@ -63,3 +63,11 @@ Key: ~ changed, + added, - removed
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/terraform-plan-json_comment_golden.md
+++ b/testdata/terraform-plan-json_comment_golden.md
@@ -63,3 +63,11 @@ Key: ~ changed, + added, - removed
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/testdata/terragrunt_comment_golden.md
+++ b/testdata/terragrunt_comment_golden.md
@@ -111,3 +111,11 @@ Key: ~ changed, + added, - removed
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ```
 </details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)


### PR DESCRIPTION
Changes are in https://github.com/infracost/actions/pull/57/commits/95ba41f9ae1d27b451d65a7d3b34496943f71fda Ignore docs commit. This has been created off a yet merged PR.

---

* Changes `comment-action` to use `infracost comment`
* Updates examples to use `infracost comment` and adds deprecation warning
* Updates tests

Pipeline was succeeding until I mucked around with the comments (deleting them on a certain commit) and now the commit action fails with this:

```
time="2022-03-11T14:26:29Z" level=info msg="Finding matching comments for tag infracost-commit"
Error: Type mismatch on variable $commitSha and argument oid (String! / GitObjectID)
Error: Process completed with exit code 1.
```

^I'm pretty sure this is because of the state of the PR and will disappear with merging.

