### PR TITLE
Corrected the `ssh-agent` command to properly call env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
       # private repositories (similar to how Terraform/Terragrunt does).
       # - name: add GIT_SSH_KEY
       #   run: |
-      #     ssh-agent -a $SSH_AUTH_SOCK
+      #     ssh-agent -a "${{ env.SSH_AUTH_SOCK }}" > /dev/null
       #     mkdir -p ~/.ssh
       #     echo "${{ secrets.GIT_SSH_KEY }}" | tr -d '\r' | ssh-add -
       #     ssh-keyscan github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
The example in the `README.md` called the `SSH_AUTH_SOCK` as if you would in bash, but to get it to run in GitHub Actions, you have to properly wrap it in double quotes and then call it via the `${{ env.<env_name> }}` method.