### PR TITLE
docs: update main example to use caching for modules and the baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ The following steps assume a simple Terraform directory is being used, we recomm
 
 ```yaml
 # The GitHub Actions docs (https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on)
-# describe other options for 'on', 'pull_request' is a good default.
-on: [pull_request]
+# describe other options for 'on'. This examples generates the cost baseline on pushes to main/master branches and
+# the cost diff and comment on pushes to the pull request branch.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
 env:
   # If you use private modules you'll need this env variable to use
   # the same ssh-agent socket value across all jobs & steps.
@@ -33,7 +39,7 @@ jobs:
       TF_ROOT: examples/terraform-project/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
       #   complements the open source CLI by giving teams advanced visibility and controls.
-      #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+      #   The cost estimates are transmitted in JSON format and do not contain any cloud
       #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
       INFRACOST_ENABLE_CLOUD: true
       # If you're using Terraform Cloud/Enterprise and have variables or private modules stored
@@ -59,22 +65,50 @@ jobs:
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
 
+      - name: Cache the Infracost baseline JSON result
+        id: cache-infracost-base-json
+        uses: actions/cache@v3
+        with:
+          path: '/tmp/infracost-base.json'
+          key: infracost-base-json-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
+
       # Checkout the base branch of the pull request (e.g. main/master).
       - name: Checkout base branch
         uses: actions/checkout@v2
         with:
           ref: '${{ github.event.pull_request.base.ref }}'
 
-      # Generate Infracost JSON file as the baseline.
+      # Downloading remote Terraform modules can be slow, so we add them to the GitHub cache.
+      # We skip this for pushes to the main/master branch that already have the baseline generated.
+      - name: Cache .infracost/terraform_modules for target branch
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**
+            !${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**/.git/**
+          key: infracost-terraform-modules-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
+          # If there's no cached record for this commit, pull in the latest cached record anyway
+          # Internally infracost will downloaded any additional required modules if required
+          restore-keys: infracost-terraform-modules-${{ runner.os }}-
+        if: github.event_name == 'pull_request' || steps.cache-infracost-base-json.outputs.cache-hit != 'true'
+
+      # Generate Infracost JSON file as the baseline. We skip this if we've already generated one for this SHA.
+      # This will also run on pull request pushes if we get a cache miss to catch cases where
+      # the baseline run hasn't been run on main/master yet.
       - name: Generate Infracost cost estimate baseline
         run: |
           infracost breakdown --path=${TF_ROOT} \
                               --format=json \
                               --out-file=/tmp/infracost-base.json
+        if: steps.cache-infracost-base-json.outputs.cache-hit != 'true'
 
       # Checkout the current PR branch so we can create a diff.
       - name: Checkout PR branch
         uses: actions/checkout@v2
+        with:
+          # Make sure the .infracost dir stays between runs so that downloaded modules persist
+          clean: false
+        if: github.event_name == 'pull_request'
 
       # Generate an Infracost diff and save it to a JSON file.
       - name: Generate Infracost diff
@@ -83,6 +117,7 @@ jobs:
                           --format=json \
                           --compare-to=/tmp/infracost-base.json \
                           --out-file=/tmp/infracost.json
+        if: github.event_name == 'pull_request'
 
       # Posts a comment to the PR using the 'update' behavior.
       # This creates a single comment and updates it. The "quietest" option.
@@ -94,10 +129,11 @@ jobs:
       - name: Post Infracost comment
         run: |
             infracost comment github --path=/tmp/infracost.json \
-                                     --repo=$GITHUB_REPOSITORY \
-                                     --github-token=${{github.token}} \
-                                     --pull-request=${{github.event.pull_request.number}} \
-                                     --behavior=update
+                                      --repo=$GITHUB_REPOSITORY \
+                                      --github-token=${{github.token}} \
+                                      --pull-request=${{github.event.pull_request.number}} \
+                                      --behavior=update
+        if: github.event_name == 'pull_request'
 ```
 
 4. 🎉 That's it! Send a new pull request to change something in Terraform that costs money. You should see a pull request comment that gets updated, e.g. the 📉 and 📈 emojis will update as changes are pushed!

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ All examples post a single comment on merge requests, which gets updated as more
 These examples work by using the default Infracost CLI option that parses HCL, thus a Terraform Plan JSON is not needed.
 
   - [Terraform/Terragrunt projects (single or multi)](terraform-project): a repository containing one or more (e.g. mono repos) Terraform or Terragrunt projects
+  - [Terraform/Terragrunt projects (using GitHub Actions cache)](terraform-project-using-cache): similar to the above example but uses the GitHub Actions cache to speed up the workflow run time
   - [Multi-projects using a config file](multi-project-config-file): repository containing multiple Terraform projects that need different inputs, i.e. variable files or Terraform workspaces
   - [Slack](slack): send cost estimates to Slack
 

--- a/examples/terraform-project/README.md
+++ b/examples/terraform-project/README.md
@@ -5,22 +5,26 @@ This example shows how to run Infracost in GitHub Actions with multiple Terrafor
 [//]: <> (BEGIN EXAMPLE)
 ```yml
 name: Terraform project
-on: [pull_request]
-
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
 env:
-  # If you use private modules you'll need this env variable to use 
-  # the same ssh-agent socket value across all jobs & steps. 
+  # If you use private modules you'll need this env variable to use
+  # the same ssh-agent socket value across all jobs & steps.
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-
 jobs:
   terraform-project:
     name: Terraform project
     runs-on: ubuntu-latest
+
     env:
       TF_ROOT: examples/terraform-project/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
       #   complements the open source CLI by giving teams advanced visibility and controls.
-      #   The cost estimates are transmitted in JSON format and do not contain any cloud 
+      #   The cost estimates are transmitted in JSON format and do not contain any cloud
       #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
       INFRACOST_ENABLE_CLOUD: true
       # If you're using Terraform Cloud/Enterprise and have variables or private modules stored
@@ -38,7 +42,7 @@ jobs:
       #     mkdir -p ~/.ssh
       #     echo "${{ secrets.GIT_SSH_KEY }}" | tr -d '\r' | ssh-add -
       #     ssh-keyscan github.com >> ~/.ssh/known_hosts
-          
+
       - name: Setup Infracost
         uses: infracost/actions/setup@v2
         # See https://github.com/infracost/actions/tree/master/setup for other inputs
@@ -46,31 +50,59 @@ jobs:
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
 
+      - name: Cache the Infracost baseline JSON result
+        id: cache-infracost-base-json
+        uses: actions/cache@v3
+        with:
+          path: '/tmp/infracost-base.json'
+          key: infracost-base-json-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
+
       # Checkout the base branch of the pull request (e.g. main/master).
       - name: Checkout base branch
         uses: actions/checkout@v2
         with:
           ref: '${{ github.event.pull_request.base.ref }}'
 
-      # Generate Infracost JSON file as the baseline.
+      # Downloading remote Terraform modules can be slow, so we add them to the GitHub cache.
+      # We skip this for pushes to the main/master branch that already have the baseline generated.
+      - name: Cache .infracost/terraform_modules for target branch
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**
+            !${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**/.git/**
+          key: infracost-terraform-modules-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
+          # If there's no cached record for this commit, pull in the latest cached record anyway
+          # Internally infracost will downloaded any additional required modules if required
+          restore-keys: infracost-terraform-modules-${{ runner.os }}-
+        if: github.event_name == 'pull_request' || steps.cache-infracost-base-json.outputs.cache-hit != 'true'
+
+      # Generate Infracost JSON file as the baseline. We skip this if we've already generated one for this SHA.
+      # This will also run on pull request pushes if we get a cache miss to catch cases where
+      # the baseline run hasn't been run on main/master yet.
       - name: Generate Infracost cost estimate baseline
         run: |
           infracost breakdown --path=${TF_ROOT} \
                               --format=json \
                               --out-file=/tmp/infracost-base.json
+        if: steps.cache-infracost-base-json.outputs.cache-hit != 'true'
 
       # Checkout the current PR branch so we can create a diff.
       - name: Checkout PR branch
         uses: actions/checkout@v2
+        with:
+          # Make sure the .infracost dir stays between runs so that downloaded modules persist
+          clean: false
+        if: github.event_name == 'pull_request'
 
       # Generate an Infracost diff and save it to a JSON file.
       - name: Generate Infracost diff
         run: |
           infracost diff --path=${TF_ROOT} \
-                              --format=json \
-                              --compare-to=/tmp/infracost-base.json \
-                              --out-file=/tmp/infracost.json
-
+                          --format=json \
+                          --compare-to=/tmp/infracost-base.json \
+                          --out-file=/tmp/infracost.json
+        if: github.event_name == 'pull_request'
 
       # Posts a comment to the PR using the 'update' behavior.
       # This creates a single comment and updates it. The "quietest" option.
@@ -81,10 +113,11 @@ jobs:
       # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
       - name: Post Infracost comment
         run: |
-          infracost comment github --path=/tmp/infracost.json \
-                                   --repo=$GITHUB_REPOSITORY \
-                                   --github-token=${{github.token}} \
-                                   --pull-request=${{github.event.pull_request.number}} \
-                                   --behavior=update
+            infracost comment github --path=/tmp/infracost.json \
+                                     --repo=$GITHUB_REPOSITORY \
+                                     --github-token=${{github.token}} \
+                                     --pull-request=${{github.event.pull_request.number}} \
+                                     --behavior=update
+        if: github.event_name == 'pull_request'
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/terraform-project/README.md
+++ b/examples/terraform-project/README.md
@@ -5,21 +5,17 @@ This example shows how to run Infracost in GitHub Actions with multiple Terrafor
 [//]: <> (BEGIN EXAMPLE)
 ```yml
 name: Terraform project
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - master
+on: [pull_request]
+
 env:
   # If you use private modules you'll need this env variable to use
   # the same ssh-agent socket value across all jobs & steps.
   SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+
 jobs:
   terraform-project:
     name: Terraform project
     runs-on: ubuntu-latest
-
     env:
       TF_ROOT: examples/terraform-project/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
@@ -50,59 +46,31 @@ jobs:
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
 
-      - name: Cache the Infracost baseline JSON result
-        id: cache-infracost-base-json
-        uses: actions/cache@v3
-        with:
-          path: '/tmp/infracost-base.json'
-          key: infracost-base-json-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
-
       # Checkout the base branch of the pull request (e.g. main/master).
       - name: Checkout base branch
         uses: actions/checkout@v2
         with:
           ref: '${{ github.event.pull_request.base.ref }}'
 
-      # Downloading remote Terraform modules can be slow, so we add them to the GitHub cache.
-      # We skip this for pushes to the main/master branch that already have the baseline generated.
-      - name: Cache .infracost/terraform_modules for target branch
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**
-            !${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**/.git/**
-          key: infracost-terraform-modules-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
-          # If there's no cached record for this commit, pull in the latest cached record anyway
-          # Internally infracost will downloaded any additional required modules if required
-          restore-keys: infracost-terraform-modules-${{ runner.os }}-
-        if: github.event_name == 'pull_request' || steps.cache-infracost-base-json.outputs.cache-hit != 'true'
-
-      # Generate Infracost JSON file as the baseline. We skip this if we've already generated one for this SHA.
-      # This will also run on pull request pushes if we get a cache miss to catch cases where
-      # the baseline run hasn't been run on main/master yet.
+      # Generate Infracost JSON file as the baseline.
       - name: Generate Infracost cost estimate baseline
         run: |
           infracost breakdown --path=${TF_ROOT} \
                               --format=json \
                               --out-file=/tmp/infracost-base.json
-        if: steps.cache-infracost-base-json.outputs.cache-hit != 'true'
 
       # Checkout the current PR branch so we can create a diff.
       - name: Checkout PR branch
         uses: actions/checkout@v2
-        with:
-          # Make sure the .infracost dir stays between runs so that downloaded modules persist
-          clean: false
-        if: github.event_name == 'pull_request'
 
       # Generate an Infracost diff and save it to a JSON file.
       - name: Generate Infracost diff
         run: |
           infracost diff --path=${TF_ROOT} \
-                          --format=json \
-                          --compare-to=/tmp/infracost-base.json \
-                          --out-file=/tmp/infracost.json
-        if: github.event_name == 'pull_request'
+                              --format=json \
+                              --compare-to=/tmp/infracost-base.json \
+                              --out-file=/tmp/infracost.json
+
 
       # Posts a comment to the PR using the 'update' behavior.
       # This creates a single comment and updates it. The "quietest" option.
@@ -113,11 +81,10 @@ jobs:
       # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
       - name: Post Infracost comment
         run: |
-            infracost comment github --path=/tmp/infracost.json \
-                                     --repo=$GITHUB_REPOSITORY \
-                                     --github-token=${{github.token}} \
-                                     --pull-request=${{github.event.pull_request.number}} \
-                                     --behavior=update
-        if: github.event_name == 'pull_request'
+          infracost comment github --path=/tmp/infracost.json \
+                                   --repo=$GITHUB_REPOSITORY \
+                                   --github-token=${{github.token}} \
+                                   --pull-request=${{github.event.pull_request.number}} \
+                                   --behavior=update
 ```
 [//]: <> (END EXAMPLE)

--- a/examples/using-cache/README.md
+++ b/examples/using-cache/README.md
@@ -1,0 +1,126 @@
+# Terraform/Terragrunt project (using the GitHub Actions cache)
+
+This example is similar to the [Terraform/Terragrunt project (single or multi)](../terraform-project) example but uses the [GitHub Actions cache](https://github.com/actions/cache) to cache the baseline result and any downloaded remote modules. This should speed up the workflow for projects that use a lot of external modules. The first time the pipeline runs it downloads all remote modules, but for subsequent runs it will retrieve them from the cache.
+
+If you have any issues running this workflow please reach out to us on [our community Slack channel](https://www.infracost.io/community-chat).
+
+[//]: <> (BEGIN EXAMPLE)
+```yml
+name: Terraform project (using the GitHub Actions cache)
+on:
+  # Run on all pull requests and pushes to the main/master branch so we can cache the baseline results.
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+env:
+  # If you use private modules you'll need this env variable to use
+  # the same ssh-agent socket value across all jobs & steps.
+  SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+jobs:
+  terraform-project-using-cache:
+    name: Terraform project (using the GitHub Actions cache)
+    runs-on: ubuntu-latest
+
+    env:
+      TF_ROOT: examples/terraform-project/code
+      # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
+      #   complements the open source CLI by giving teams advanced visibility and controls.
+      #   The cost estimates are transmitted in JSON format and do not contain any cloud
+      #   credentials or secrets (see https://infracost.io/docs/faq/ for more information).
+      INFRACOST_ENABLE_CLOUD: true
+      # If you're using Terraform Cloud/Enterprise and have variables or private modules stored
+      # on there, specify the following to automatically retrieve the variables:
+      #   INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TFC_TOKEN }}
+      #   INFRACOST_TERRAFORM_CLOUD_HOST: app.terraform.io # Change this if you're using Terraform Enterprise
+
+    steps:
+      # If you use private modules, add an environment variable or secret
+      # called GIT_SSH_KEY with your private key, so Infracost can access
+      # private repositories (similar to how Terraform/Terragrunt does).
+      # - name: add GIT_SSH_KEY
+      #   run: |
+      #     ssh-agent -a $SSH_AUTH_SOCK
+      #     mkdir -p ~/.ssh
+      #     echo "${{ secrets.GIT_SSH_KEY }}" | tr -d '\r' | ssh-add -
+      #     ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Setup Infracost
+        uses: infracost/actions/setup@v2
+        # See https://github.com/infracost/actions/tree/master/setup for other inputs
+        # If you can't use this action, see Docker images in https://infracost.io/cicd
+        with:
+          api-key: ${{ secrets.INFRACOST_API_KEY }}
+
+      - name: Cache the Infracost baseline JSON result
+        id: cache-infracost-base-json
+        uses: actions/cache@v3
+        with:
+          path: '/tmp/infracost-base.json'
+          key: infracost-base-json-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
+
+      # Checkout the base branch of the pull request (e.g. main/master).
+      - name: Checkout base branch
+        uses: actions/checkout@v2
+        with:
+          ref: '${{ github.event.pull_request.base.ref }}'
+
+      # Downloading remote Terraform modules can be slow, so we add them to the GitHub cache.
+      # We skip this for pushes to the main/master branch that already have the baseline generated.
+      - name: Cache .infracost/terraform_modules for target branch
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**
+            !${{ env.TF_ROOT }}/**/.infracost/terraform_modules/**/.git/**
+          key: infracost-terraform-modules-${{ runner.os }}-${{ github.event.pull_request.base.sha || github.sha }}
+          # If there's no cached record for this commit, pull in the latest cached record anyway
+          # Internally infracost will downloaded any additional required modules if required
+          restore-keys: infracost-terraform-modules-${{ runner.os }}-
+        if: github.event_name == 'pull_request' || steps.cache-infracost-base-json.outputs.cache-hit != 'true'
+
+      # Generate Infracost JSON file as the baseline. We skip this if we've already generated one for this SHA.
+      # This will also run on pull request pushes if we get a cache miss to catch cases where
+      # the baseline run hasn't been run on main/master yet.
+      - name: Generate Infracost cost estimate baseline
+        run: |
+          infracost breakdown --path=${TF_ROOT} \
+                              --format=json \
+                              --out-file=/tmp/infracost-base.json
+        if: steps.cache-infracost-base-json.outputs.cache-hit != 'true'
+
+      # Checkout the current PR branch so we can create a diff.
+      - name: Checkout PR branch
+        uses: actions/checkout@v2
+        with:
+          # Make sure the .infracost dir stays between runs so that downloaded modules persist
+          clean: false
+        if: github.event_name == 'pull_request'
+
+      # Generate an Infracost diff and save it to a JSON file.
+      - name: Generate Infracost diff
+        run: |
+          infracost diff --path=${TF_ROOT} \
+                          --format=json \
+                          --compare-to=/tmp/infracost-base.json \
+                          --out-file=/tmp/infracost.json
+        if: github.event_name == 'pull_request'
+
+      # Posts a comment to the PR using the 'update' behavior.
+      # This creates a single comment and updates it. The "quietest" option.
+      # The other valid behaviors are:
+      #   delete-and-new - Delete previous comments and create a new one.
+      #   hide-and-new - Minimize previous comments and create a new one.
+      #   new - Create a new cost estimate comment on every push.
+      # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
+      - name: Post Infracost comment
+        run: |
+            infracost comment github --path=/tmp/infracost.json \
+                                     --repo=$GITHUB_REPOSITORY \
+                                     --github-token=${{github.token}} \
+                                     --pull-request=${{github.event.pull_request.number}} \
+                                     --behavior=update
+        if: github.event_name == 'pull_request'
+```
+[//]: <> (END EXAMPLE)

--- a/testdata/terraform-project-using-cache_comment_golden copy.md
+++ b/testdata/terraform-project-using-cache_comment_golden copy.md
@@ -1,0 +1,77 @@
+
+💰 Infracost estimate: **monthly cost will increase by $586 (+73%) 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/actions/examples/terraform-project/code/dev</td>
+      <td align="right">$51.97</td>
+      <td align="right">$77.37</td>
+      <td>+$25.40 (+49%)</td>
+    </tr>
+    <tr>
+      <td>infracost/actions/examples/terraform-project/code/prod</td>
+      <td align="right">$748</td>
+      <td align="right">$1,308</td>
+      <td>+$561 (+75%)</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$800</td>
+      <td align="right">$1,386</td>
+      <td>+$586 (+73%)</td>
+    </tr>
+  </tbody>
+</table>
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/actions/examples/terraform-project/code/dev
+Module path: dev
+
+~ module.base.aws_instance.web_app
+  +$25.40 ($51.97 → $77.37)
+
+    ~ Instance usage (Linux/UNIX, on-demand, t2.micro → t2.medium)
+      +$25.40 ($8.47 → $33.87)
+
+Monthly cost change for infracost/actions/examples/terraform-project/code/dev (Module path: dev)
+Amount:  +$25.40 ($51.97 → $77.37)
+Percent: +49%
+
+──────────────────────────────────
+Project: infracost/actions/examples/terraform-project/code/prod
+Module path: prod
+
+~ module.base.aws_instance.web_app
+  +$561 ($748 → $1,308)
+
+    ~ Instance usage (Linux/UNIX, on-demand, m5.4xlarge → m5.8xlarge)
+      +$561 ($561 → $1,121)
+
+Monthly cost change for infracost/actions/examples/terraform-project/code/prod (Module path: prod)
+Amount:  +$561 ($748 → $1,308)
+Percent: +75%
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+4 cloud resources were detected:
+∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+```
+</details>
+
+This comment will be updated when the cost estimate changes.
+
+<sub>
+  Is this comment useful? <a href="https://dashboard.infracost.io/feedback/redirect?runId=&value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://dashboard.infracost.io/feedback/redirect?runId=&value=no" rel="noopener noreferrer" target="_blank">No</a>, <a href="https://dashboard.infracost.io/feedback/redirect?runId=&value=other" rel="noopener noreferrer" target="_blank">Other</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)


### PR DESCRIPTION
This adds an example that uses the GitHub Action cache to cache the baseline result and the downloaded remote modules.