### PR TITLE
Add permissions to the example action definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ jobs:
   infracost:
     name: Infracost
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     env:
       TF_ROOT: examples/terraform-project/code

--- a/examples/multi-project-config-file/README.md
+++ b/examples/multi-project-config-file/README.md
@@ -15,6 +15,9 @@ jobs:
   multi-project-config-file:
     name: Multi-project config file
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/multi-project-config-file/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product

--- a/examples/plan-json/multi-project-matrix/README.md
+++ b/examples/plan-json/multi-project-matrix/README.md
@@ -12,6 +12,9 @@ jobs:
   multi-project-matrix:
     name: Multi-project matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
@@ -74,6 +77,9 @@ jobs:
   multi-project-matrix-merge:
     name: Multi-project matrix merge
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     needs: [multi-project-matrix]
 
     steps:

--- a/examples/plan-json/multi-workspace-matrix/README.md
+++ b/examples/plan-json/multi-workspace-matrix/README.md
@@ -11,6 +11,9 @@ jobs:
   multi-workspace-matrix:
     name: Multi-workspace matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/plan-json/multi-workspace-matrix/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product
@@ -75,6 +78,9 @@ jobs:
   multi-workspace-matrix-merge:
     name: Multi-workspace matrix merge
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     needs: [multi-workspace-matrix]
 
     steps:

--- a/examples/plan-json/terraform-cloud-enterprise/README.md
+++ b/examples/plan-json/terraform-cloud-enterprise/README.md
@@ -11,6 +11,9 @@ jobs:
   terraform-cloud-enterprise:
     name: Terraform Cloud/Enterprise
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/plan-json/terraform-cloud-enterprise/code
       TFC_HOST: app.terraform.io # Change this if you're using Terraform Enterprise

--- a/examples/plan-json/terragrunt/README.md
+++ b/examples/plan-json/terragrunt/README.md
@@ -11,6 +11,9 @@ jobs:
   terragrunt-project:
     name: Terragrunt project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/plan-json/terragrunt/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product

--- a/examples/sentinel/README.md
+++ b/examples/sentinel/README.md
@@ -66,6 +66,9 @@ jobs:
   sentinel:
     name: Sentinel
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code
 

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -19,6 +19,9 @@ jobs:
   slack:
     name: Slack
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product

--- a/examples/terraform-project/README.md
+++ b/examples/terraform-project/README.md
@@ -16,6 +16,9 @@ jobs:
   terraform-project:
     name: Terraform project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code
       # This instructs the CLI to send cost estimates to Infracost Cloud. Our SaaS product

--- a/examples/using-cache/README.md
+++ b/examples/using-cache/README.md
@@ -22,6 +22,9 @@ jobs:
   terraform-project-using-cache:
     name: Terraform project (using the GitHub Actions cache)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     env:
       TF_ROOT: examples/terraform-project/code


### PR DESCRIPTION
These are the minimum permissions needed to run Infracost. I use these on my own workflows.