### PR TITLE
docs: Clarify token permissions with new read-only defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
 
     env:
@@ -114,7 +115,7 @@ jobs:
 
 #### Permissions issue
 
-If you receive an error when running the `infracost comment` command in your pipeline, it's probably related to `${{ github.token }}`. This is the default GitHub token available to actions and is used to post comments. The default [token permissions](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions) work fine but `pull-requests: write` is required if you need to customize these. If you are using SAML single sign-on, you must first [authorize the token](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
+If you receive an error when running the `infracost comment` command in your pipeline, it's probably related to `${{ github.token }}`. This is the default GitHub token available to actions and is used to post comments. The default [token permissions](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions) are read-only by default and `pull-requests: write` is required. If you are using SAML single sign-on, you must first [authorize the token](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
 
 #### The `add GIT_SSH_KEY` step fails
 

--- a/examples/multi-project-config-file/README.md
+++ b/examples/multi-project-config-file/README.md
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/multi-project-config-file/code

--- a/examples/plan-json/multi-project-matrix/README.md
+++ b/examples/plan-json/multi-project-matrix/README.md
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code

--- a/examples/plan-json/multi-workspace-matrix/README.md
+++ b/examples/plan-json/multi-workspace-matrix/README.md
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/plan-json/multi-workspace-matrix/code
@@ -75,6 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     needs: [multi-workspace-matrix]
 

--- a/examples/plan-json/terraform-cloud-enterprise/README.md
+++ b/examples/plan-json/terraform-cloud-enterprise/README.md
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/plan-json/terraform-cloud-enterprise/code

--- a/examples/plan-json/terragrunt/README.md
+++ b/examples/plan-json/terragrunt/README.md
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/plan-json/terragrunt/code

--- a/examples/sentinel/README.md
+++ b/examples/sentinel/README.md
@@ -68,6 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code

--- a/examples/terraform-project/README.md
+++ b/examples/terraform-project/README.md
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
     env:
       TF_ROOT: examples/terraform-project/code

--- a/examples/using-cache/README.md
+++ b/examples/using-cache/README.md
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to post comments
       pull-requests: write
 
     env:


### PR DESCRIPTION
Default read-only repo permissions, no permissions specified in the workflow, failed to post a comment:
```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  Packages: read
```

Default read-only repo permissions, `pull-requests: write` specified in the workflow, posted a comment okay:
```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  PullRequests: write
```