### PR TITLE
docs(gha): use new syntax for setting outputs examples

### DIFF
--- a/.github/workflows/examples_test.yml
+++ b/.github/workflows/examples_test.yml
@@ -568,11 +568,11 @@ jobs:
       - name: Generate Slack message
         id: infracost-slack
         run: >
-          echo "::set-output name=slack-message::$(infracost output
-          --path=/tmp/infracost.json --format=slack-message --show-skipped)"
+          echo "slack-message=$(infracost output
+          --path=/tmp/infracost.json --format=slack-message --show-skipped)" >> $GITHUB_OUTPUT
 
-          echo "::set-output name=diffTotalMonthlyCost::$(jq
-          '(.diffTotalMonthlyCost // 0) | tonumber' /tmp/infracost.json)"
+          echo "diffTotalMonthlyCost=$(jq
+          '(.diffTotalMonthlyCost // 0) | tonumber' /tmp/infracost.json)" >> $GITHUB_OUTPUT
       - name: Generate Slack message
         run: >-
           infracost output --path=/tmp/infracost.json --format=slack-message

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -87,8 +87,8 @@ jobs:
       - name: Generate Slack message
         id: infracost-slack
         run: |
-          echo "::set-output name=slack-message::$(infracost output --path=/tmp/infracost.json --format=slack-message --show-skipped)"
-          echo "::set-output name=diffTotalMonthlyCost::$(jq '(.diffTotalMonthlyCost // 0) | tonumber' /tmp/infracost.json)"
+          echo "slack-message=$(infracost output --path=/tmp/infracost.json --format=slack-message --show-skipped)" >> $GITHUB_OUTPUT
+          echo "diffTotalMonthlyCost=$(jq '(.diffTotalMonthlyCost // 0) | tonumber' /tmp/infracost.json)" >> $GITHUB_OUTPUT
 
       - name: Send cost estimate to Slack
         uses: slackapi/slack-github-action@v1


### PR DESCRIPTION
## Why

The action uses the new syntax of `set-outputs`, but the doc is not updated