### PR TITLE
Add infracost-run and cloud-issue-fixed event tracking

### DIFF
--- a/tools/scanner/internal/commands/diff.go
+++ b/tools/scanner/internal/commands/diff.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/infracost/actions/tools/scanner/internal/api"
 	"github.com/infracost/actions/tools/scanner/internal/config"
@@ -91,6 +92,7 @@ func newVCSClient(ctx context.Context, args *diffArgs) (vcs.VCS, error) {
 
 func diff(cfg *config.Config, args *diffArgs, vcsClient vcs.VCS, results *ScanResult) error {
 	ctx := context.Background()
+	startTime := time.Now()
 
 	headCommitSHA := git.RevParse(args.headPath, "HEAD")
 	headBranch := git.RevParse(args.headPath, "--abbrev-ref", "HEAD")
@@ -211,6 +213,10 @@ func diff(cfg *config.Config, args *diffArgs, vcsClient vcs.VCS, results *ScanRe
 	if _, err := vcsClient.PostComment(ctx, body, vcs.BehaviorUpdate); err != nil {
 		return fmt.Errorf("failed to post comment: %w", err)
 	}
+
+	eventsClient := cfg.Events.Client(httpClient)
+	trackRun(ctx, eventsClient, headResult, baseResult, time.Since(startTime).Seconds(), "comment")
+	trackDiff(ctx, eventsClient, headResult, baseResult)
 
 	checkBlockingViolations(data, runParams.Guardrails, results)
 	return nil

--- a/tools/scanner/internal/commands/diff_integration_test.go
+++ b/tools/scanner/internal/commands/diff_integration_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"math/big"
@@ -52,6 +53,29 @@ func setupDashboardAddRun(m *testingconfig.Mocks) {
 			ID:       "test-run-id",
 			CloudURL: "https://dashboard.infracost.io/org/test-org/repos/test-repo-id/runs/test-run-id",
 		}, nil)
+}
+
+// setupEventsMocks configures the events mock to accept Push calls and captures
+// the infracost-run event metadata for verification.
+func setupEventsMocks(m *testingconfig.Mocks) *map[string]interface{} {
+	captured := make(map[string]interface{})
+	m.Events.EXPECT().
+		Push(mock.Anything, "infracost-run", mock.Anything).
+		Run(func(_ context.Context, _ string, extra ...interface{}) {
+			for i := 0; i < len(extra); i += 2 {
+				if key, ok := extra[i].(string); ok {
+					captured[key] = extra[i+1]
+				}
+			}
+		}).
+		Return().
+		Once()
+	// Allow any number of cloud-issue-fixed events.
+	m.Events.EXPECT().
+		Push(mock.Anything, "cloud-issue-fixed", mock.Anything).
+		Return().
+		Maybe()
+	return &captured
 }
 
 // setupVCSMocks configures the VCS mock to capture comment.Data and accept PostComment.
@@ -117,6 +141,7 @@ func TestDiff_BasicCostDiff(t *testing.T) {
 
 	setupDashboardAddRun(m)
 	data := setupVCSMocks(m)
+	runEvent := setupEventsMocks(m)
 
 	_, err := runDiff(t, &cfg, m, filepath.Join(testdataDir(), "basic", "base"), filepath.Join(testdataDir(), "basic", "head"))
 	if err != nil {
@@ -139,6 +164,15 @@ func TestDiff_BasicCostDiff(t *testing.T) {
 	if project.DiffBreakdown == nil || project.DiffBreakdown.TotalMonthlyCost == nil || project.DiffBreakdown.TotalMonthlyCost.IsZero() {
 		t.Error("expected non-zero diff breakdown cost")
 	}
+
+	// Verify event tracking was called with diff metadata.
+	env := *runEvent
+	if env["outputFormat"] != "comment" {
+		t.Errorf("expected outputFormat 'comment', got %v", env["outputFormat"])
+	}
+	if _, ok := env["newResourceCount"]; !ok {
+		t.Error("expected newResourceCount in infracost-run event for diff")
+	}
 }
 
 func TestDiff_NoChanges(t *testing.T) {
@@ -151,6 +185,7 @@ func TestDiff_NoChanges(t *testing.T) {
 
 	setupDashboardAddRun(m)
 	data := setupVCSMocks(m)
+	setupEventsMocks(m)
 
 	_, err := runDiff(t, &cfg, m, filepath.Join(testdataDir(), "no-changes", "base"), filepath.Join(testdataDir(), "no-changes", "head"))
 	if err != nil {
@@ -243,6 +278,7 @@ func TestDiff_GuardrailTriggered(t *testing.T) {
 
 	setupDashboardAddRun(m)
 	data := setupVCSMocks(m)
+	setupEventsMocks(m)
 
 	result, err := runDiff(t, &cfg, m, filepath.Join(testdataDir(), "basic", "base"), filepath.Join(testdataDir(), "basic", "head"))
 	if err != nil {
@@ -290,6 +326,7 @@ func TestDiff_GuardrailSuppressed(t *testing.T) {
 
 	setupDashboardAddRun(m)
 	data := setupVCSMocks(m)
+	setupEventsMocks(m)
 
 	result, err := runDiff(t, &cfg, m, filepath.Join(testdataDir(), "no-changes", "base"), filepath.Join(testdataDir(), "no-changes", "head"))
 	if err != nil {
@@ -336,6 +373,7 @@ func TestDiff_FinOpsPolicy(t *testing.T) {
 
 	setupDashboardAddRun(m)
 	data := setupVCSMocks(m)
+	setupEventsMocks(m)
 
 	_, err := runDiff(t, &cfg, m, filepath.Join(testdataDir(), "basic", "base"), filepath.Join(testdataDir(), "basic", "head"))
 	if err != nil {
@@ -374,6 +412,7 @@ func TestDiff_UsageDefaults(t *testing.T) {
 
 	setupDashboardAddRun(m)
 	data := setupVCSMocks(m)
+	setupEventsMocks(m)
 
 	_, err := runDiff(t, &cfg, m, filepath.Join(testdataDir(), "basic", "base"), filepath.Join(testdataDir(), "basic", "head"))
 	if err != nil {
@@ -395,6 +434,7 @@ func TestDiff_SingleProjectFilter(t *testing.T) {
 
 	setupDashboardAddRun(m)
 	data := setupVCSMocks(m)
+	setupEventsMocks(m)
 
 	_, err := runDiffWithArgs(t, &cfg, m, filepath.Join(testdataDir(), "multi-project", "base"), filepath.Join(testdataDir(), "multi-project", "head"), diffArgs{project: "web"})
 	if err != nil {

--- a/tools/scanner/internal/commands/events.go
+++ b/tools/scanner/internal/commands/events.go
@@ -1,0 +1,288 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/infracost/actions/tools/scanner/internal/api/events"
+	"github.com/infracost/actions/tools/scanner/internal/config"
+	pkgscanner "github.com/infracost/cli/pkg/scanner"
+	goprotoevent "github.com/infracost/go-proto/pkg/event"
+	"github.com/infracost/proto/gen/go/infracost/provider"
+)
+
+// trackRun fires an "infracost-run" event with resource counts, usage info,
+// and (when a previous result is available) diff counts.
+func trackRun(ctx context.Context, client events.Client, result *config.DirectoryResult, prev *config.DirectoryResult, runSeconds float64, outputFormat string) {
+	var totalResources int
+	var totalSupported int
+	var totalNoPrice int
+	var totalUnsupported int
+
+	supportedCounts := make(map[string]int)
+	unsupportedCounts := make(map[string]int)
+
+	var supportedList []string
+	var unsupportedList []string
+
+	for _, p := range result.Projects {
+		for _, r := range p.Resources {
+			totalResources++
+
+			switch {
+			case !r.IsSupported:
+				totalUnsupported++
+				unsupportedCounts[r.Type]++
+				unsupportedList = append(unsupportedList, r.Type)
+			case r.IsFree:
+				totalNoPrice++
+			default:
+				totalSupported++
+				supportedCounts[r.Type]++
+				supportedList = append(supportedList, r.Type)
+			}
+		}
+	}
+
+	extra := []interface{}{
+		"runSeconds", runSeconds,
+		"outputFormat", outputFormat,
+		"totalResources", totalResources,
+		"totalSupportedResources", totalSupported,
+		"totalNoPriceResources", totalNoPrice,
+		"totalUnsupportedResources", totalUnsupported,
+		"supportedResourceCounts", supportedCounts,
+		"supportedResourcesList", supportedList,
+		"unsupportedResourceCounts", unsupportedCounts,
+		"unsupportedResourcesList", unsupportedList,
+	}
+
+	hasUsageFile := result.EstimatedUsageCounts != nil
+	extra = append(extra, "hasUsageFile", hasUsageFile)
+	if hasUsageFile {
+		var totalEstimated int
+		var totalUnestimated int
+		var estimatedList []string
+		var unestimatedList []string
+
+		for key, count := range result.EstimatedUsageCounts {
+			totalEstimated += count
+			for range count {
+				estimatedList = append(estimatedList, key)
+			}
+		}
+		for key, count := range result.UnestimatedUsageCounts {
+			totalUnestimated += count
+			for range count {
+				unestimatedList = append(unestimatedList, key)
+			}
+		}
+
+		extra = append(extra,
+			"totalEstimatedUsages", totalEstimated,
+			"totalUnestimatedUsages", totalUnestimated,
+			"estimatedUsageCounts", result.EstimatedUsageCounts,
+			"estimatedUsageList", estimatedList,
+			"unestimatedUsageCounts", result.UnestimatedUsageCounts,
+			"unestimatedUsageList", unestimatedList,
+		)
+	}
+
+	if prev != nil {
+		diff := computeRunDiff(result, prev)
+		extra = append(extra,
+			"newResourceCount", diff.newResources,
+			"changedResourceCount", diff.changedResources,
+			"newIssueCount", diff.newIssues,
+			"existingIssueCount", diff.existingIssues,
+		)
+	}
+
+	client.Push(ctx, "infracost-run", extra...)
+}
+
+// trackDiff compares head results against base results and fires a
+// "cloud-issue-fixed" event for every policy violation that was present in
+// base but is no longer present in head. Projects are matched by name.
+func trackDiff(ctx context.Context, client events.Client, head *config.DirectoryResult, base *config.DirectoryResult) {
+	if base == nil {
+		return
+	}
+
+	prev := make(map[string]*pkgscanner.ProjectResult, len(base.Projects))
+	for i := range base.Projects {
+		prev[base.Projects[i].Name] = &base.Projects[i]
+	}
+
+	for i := range head.Projects {
+		p := &head.Projects[i]
+		old, ok := prev[p.Name]
+		if !ok {
+			continue
+		}
+		trackFinopsDiff(ctx, client, p, old.FinopsResults)
+		trackTaggingDiff(ctx, client, p, old.TagPolicyResults)
+	}
+}
+
+type runDiffCounts struct {
+	newResources     int
+	changedResources int
+	newIssues        int
+	existingIssues   int
+}
+
+func computeRunDiff(current, previous *config.DirectoryResult) runDiffCounts {
+	var counts runDiffCounts
+
+	prev := make(map[string]pkgscanner.ProjectResult, len(previous.Projects))
+	for _, p := range previous.Projects {
+		prev[p.Name] = p
+	}
+
+	for _, p := range current.Projects {
+		old, ok := prev[p.Name]
+		if !ok {
+			counts.newResources += len(p.Resources)
+			counts.newIssues += countIssues(p)
+			continue
+		}
+
+		newRes, changedRes := countResourceDiff(p, old)
+		counts.newResources += newRes
+		counts.changedResources += changedRes
+
+		newIss, existingIss := countIssueDiff(p, old)
+		counts.newIssues += newIss
+		counts.existingIssues += existingIss
+	}
+
+	return counts
+}
+
+func countResourceDiff(current, previous pkgscanner.ProjectResult) (newResources, changedResources int) {
+	prevChecksums := make(map[string]string, len(previous.Resources))
+	for _, r := range previous.Resources {
+		prevChecksums[r.Name] = r.Metadata.GetDeepChecksum()
+	}
+
+	for _, r := range current.Resources {
+		oldChecksum, ok := prevChecksums[r.Name]
+		if !ok {
+			newResources++
+			continue
+		}
+		if r.Metadata.GetDeepChecksum() != "" && oldChecksum != "" && r.Metadata.GetDeepChecksum() != oldChecksum {
+			changedResources++
+		}
+	}
+
+	return newResources, changedResources
+}
+
+func countIssueDiff(current, previous pkgscanner.ProjectResult) (newIssues, existingIssues int) {
+	prevIssues := make(map[string]struct{})
+
+	for _, r := range previous.FinopsResults {
+		for _, fr := range r.FailingResources {
+			prevIssues[r.PolicySlug+"\x00"+fr.CauseAddress] = struct{}{}
+		}
+	}
+	for _, r := range previous.TagPolicyResults {
+		for _, fr := range r.FailingResources {
+			prevIssues[r.TagPolicyID+"\x00"+fr.Address] = struct{}{}
+		}
+	}
+
+	for _, r := range current.FinopsResults {
+		for _, fr := range r.FailingResources {
+			key := r.PolicySlug + "\x00" + fr.CauseAddress
+			if _, ok := prevIssues[key]; ok {
+				existingIssues++
+			} else {
+				newIssues++
+			}
+		}
+	}
+	for _, r := range current.TagPolicyResults {
+		for _, fr := range r.FailingResources {
+			key := r.TagPolicyID + "\x00" + fr.Address
+			if _, ok := prevIssues[key]; ok {
+				existingIssues++
+			} else {
+				newIssues++
+			}
+		}
+	}
+
+	return newIssues, existingIssues
+}
+
+func countIssues(p pkgscanner.ProjectResult) int {
+	var total int
+	for _, r := range p.FinopsResults {
+		total += len(r.FailingResources)
+	}
+	for _, r := range p.TagPolicyResults {
+		total += len(r.FailingResources)
+	}
+	return total
+}
+
+func trackFinopsDiff(ctx context.Context, client events.Client, p *pkgscanner.ProjectResult, other []*provider.FinopsPolicyResult) {
+	current := make(map[string]map[string]struct{})
+	for _, r := range p.FinopsResults {
+		addrs := make(map[string]struct{}, len(r.FailingResources))
+		for _, fr := range r.FailingResources {
+			addrs[fr.CauseAddress] = struct{}{}
+		}
+		current[r.PolicySlug] = addrs
+	}
+
+	for _, prev := range other {
+		for _, fr := range prev.FailingResources {
+			if cur, ok := current[prev.PolicySlug]; ok {
+				if _, still := cur[fr.CauseAddress]; still {
+					continue
+				}
+			}
+			client.Push(ctx, "cloud-issue-fixed",
+				"policyId", prev.PolicyId,
+				"policySlug", prev.PolicySlug,
+				"type", "finops-policy",
+				"projectName", p.Name,
+				"resourceAddress", fr.CauseAddress,
+				"pullRequestId", "",
+				"autoFixPullRequest", false,
+			)
+		}
+	}
+}
+
+func trackTaggingDiff(ctx context.Context, client events.Client, p *pkgscanner.ProjectResult, other []goprotoevent.TaggingPolicyResult) {
+	current := make(map[string]map[string]struct{})
+	for _, r := range p.TagPolicyResults {
+		addrs := make(map[string]struct{}, len(r.FailingResources))
+		for _, fr := range r.FailingResources {
+			addrs[fr.Address] = struct{}{}
+		}
+		current[r.TagPolicyID] = addrs
+	}
+
+	for _, prev := range other {
+		for _, fr := range prev.FailingResources {
+			if cur, ok := current[prev.TagPolicyID]; ok {
+				if _, still := cur[fr.Address]; still {
+					continue
+				}
+			}
+			client.Push(ctx, "cloud-issue-fixed",
+				"policyId", prev.TagPolicyID,
+				"type", "tag-policy",
+				"projectName", p.Name,
+				"resourceAddress", fr.Address,
+				"pullRequestId", "",
+				"autoFixPullRequest", false,
+			)
+		}
+	}
+}

--- a/tools/scanner/internal/commands/events_test.go
+++ b/tools/scanner/internal/commands/events_test.go
@@ -1,0 +1,367 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/infracost/actions/tools/scanner/internal/api/events/mocks"
+	"github.com/infracost/actions/tools/scanner/internal/config"
+	pkgscanner "github.com/infracost/cli/pkg/scanner"
+	goprotoevent "github.com/infracost/go-proto/pkg/event"
+	"github.com/infracost/proto/gen/go/infracost/provider"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTrackRun_BasicResourceCounts(t *testing.T) {
+	client := mocks.NewMockClient(t)
+
+	result := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "project-a",
+				Resources: []*provider.Resource{
+					{Name: "aws_instance.web", Type: "aws_instance", IsSupported: true},
+					{Name: "aws_instance.api", Type: "aws_instance", IsSupported: true},
+					{Name: "aws_s3_bucket.logs", Type: "aws_s3_bucket", IsSupported: true, IsFree: true},
+					{Name: "aws_custom.thing", Type: "aws_custom", IsSupported: false},
+				},
+			},
+		},
+	}
+
+	var captured []interface{}
+	client.EXPECT().
+		Push(mock.Anything, "infracost-run", mock.Anything).
+		Run(func(_ context.Context, _ string, extra ...interface{}) {
+			captured = extra
+		}).
+		Return()
+
+	trackRun(context.Background(), client, result, nil, 1.5, "upload")
+
+	env := toMap(t, captured)
+	assertEq(t, env, "totalResources", 4)
+	assertEq(t, env, "totalSupportedResources", 2)
+	assertEq(t, env, "totalNoPriceResources", 1)
+	assertEq(t, env, "totalUnsupportedResources", 1)
+	assertEq(t, env, "runSeconds", 1.5)
+	assertEq(t, env, "outputFormat", "upload")
+	assertEq(t, env, "hasUsageFile", false)
+
+	// No diff fields when prev is nil.
+	if _, ok := env["newResourceCount"]; ok {
+		t.Error("expected no newResourceCount when prev is nil")
+	}
+}
+
+func TestTrackRun_WithUsageFile(t *testing.T) {
+	client := mocks.NewMockClient(t)
+
+	result := &config.DirectoryResult{
+		Projects:               []pkgscanner.ProjectResult{{Name: "p"}},
+		EstimatedUsageCounts:   map[string]int{"aws_instance.monthly_hrs": 2},
+		UnestimatedUsageCounts: map[string]int{"aws_lambda.requests": 1},
+	}
+
+	var captured []interface{}
+	client.EXPECT().
+		Push(mock.Anything, "infracost-run", mock.Anything).
+		Run(func(_ context.Context, _ string, extra ...interface{}) {
+			captured = extra
+		}).
+		Return()
+
+	trackRun(context.Background(), client, result, nil, 0.5, "upload")
+
+	env := toMap(t, captured)
+	assertEq(t, env, "hasUsageFile", true)
+	assertEq(t, env, "totalEstimatedUsages", 2)
+	assertEq(t, env, "totalUnestimatedUsages", 1)
+}
+
+func TestTrackRun_WithDiff(t *testing.T) {
+	client := mocks.NewMockClient(t)
+
+	prev := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				Resources: []*provider.Resource{
+					{Name: "aws_instance.web", Type: "aws_instance", IsSupported: true, Metadata: &provider.ResourceMetadata{DeepChecksum: "aaa"}},
+				},
+			},
+		},
+	}
+	current := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				Resources: []*provider.Resource{
+					{Name: "aws_instance.web", Type: "aws_instance", IsSupported: true, Metadata: &provider.ResourceMetadata{DeepChecksum: "bbb"}},
+					{Name: "aws_instance.api", Type: "aws_instance", IsSupported: true, Metadata: &provider.ResourceMetadata{DeepChecksum: "ccc"}},
+				},
+			},
+		},
+	}
+
+	var captured []interface{}
+	client.EXPECT().
+		Push(mock.Anything, "infracost-run", mock.Anything).
+		Run(func(_ context.Context, _ string, extra ...interface{}) {
+			captured = extra
+		}).
+		Return()
+
+	trackRun(context.Background(), client, current, prev, 2.0, "comment")
+
+	env := toMap(t, captured)
+	assertEq(t, env, "newResourceCount", 1)
+	assertEq(t, env, "changedResourceCount", 1)
+}
+
+func TestTrackDiff_FinopsFixed(t *testing.T) {
+	client := mocks.NewMockClient(t)
+
+	base := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				FinopsResults: []*provider.FinopsPolicyResult{
+					{
+						PolicyId:   "fp-1",
+						PolicySlug: "aws-gp2-volumes",
+						FailingResources: []*provider.FinopsPolicyFailingResource{
+							{CauseAddress: "aws_ebs_volume.old"},
+							{CauseAddress: "aws_ebs_volume.still_bad"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	head := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				FinopsResults: []*provider.FinopsPolicyResult{
+					{
+						PolicyId:   "fp-1",
+						PolicySlug: "aws-gp2-volumes",
+						FailingResources: []*provider.FinopsPolicyFailingResource{
+							{CauseAddress: "aws_ebs_volume.still_bad"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Expect one cloud-issue-fixed for the resolved violation.
+	client.EXPECT().
+		Push(mock.Anything, "cloud-issue-fixed", mock.Anything).
+		Run(func(_ context.Context, _ string, extra ...interface{}) {
+			env := toMap(t, extra)
+			assertEq(t, env, "policyId", "fp-1")
+			assertEq(t, env, "policySlug", "aws-gp2-volumes")
+			assertEq(t, env, "type", "finops-policy")
+			assertEq(t, env, "resourceAddress", "aws_ebs_volume.old")
+		}).
+		Return().
+		Once()
+
+	trackDiff(context.Background(), client, head, base)
+}
+
+func TestTrackDiff_TaggingFixed(t *testing.T) {
+	client := mocks.NewMockClient(t)
+
+	base := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				TagPolicyResults: []goprotoevent.TaggingPolicyResult{
+					{
+						TagPolicyID: "tp-1",
+						FailingResources: []goprotoevent.TagPolicyResultResource{
+							{Address: "aws_instance.untagged"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	head := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name:             "p",
+				TagPolicyResults: []goprotoevent.TaggingPolicyResult{},
+			},
+		},
+	}
+
+	client.EXPECT().
+		Push(mock.Anything, "cloud-issue-fixed", mock.Anything).
+		Run(func(_ context.Context, _ string, extra ...interface{}) {
+			env := toMap(t, extra)
+			assertEq(t, env, "policyId", "tp-1")
+			assertEq(t, env, "type", "tag-policy")
+			assertEq(t, env, "resourceAddress", "aws_instance.untagged")
+		}).
+		Return().
+		Once()
+
+	trackDiff(context.Background(), client, head, base)
+}
+
+func TestTrackDiff_NilBase(t *testing.T) {
+	client := mocks.NewMockClient(t)
+	// No Push calls expected.
+	trackDiff(context.Background(), client, &config.DirectoryResult{}, nil)
+}
+
+func TestTrackDiff_NoMatchingProject(t *testing.T) {
+	client := mocks.NewMockClient(t)
+
+	base := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{{Name: "old-project"}},
+	}
+	head := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{{Name: "new-project"}},
+	}
+
+	// No Push calls expected — projects don't match.
+	trackDiff(context.Background(), client, head, base)
+}
+
+func TestTrackDiff_NothingFixed(t *testing.T) {
+	client := mocks.NewMockClient(t)
+
+	results := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				FinopsResults: []*provider.FinopsPolicyResult{
+					{
+						PolicySlug: "pol",
+						FailingResources: []*provider.FinopsPolicyFailingResource{
+							{CauseAddress: "r1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Same violations in base and head — no events.
+	trackDiff(context.Background(), client, results, results)
+}
+
+func TestComputeRunDiff_NewProject(t *testing.T) {
+	prev := &config.DirectoryResult{}
+	current := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "new-project",
+				Resources: []*provider.Resource{
+					{Name: "r1"},
+					{Name: "r2"},
+				},
+				FinopsResults: []*provider.FinopsPolicyResult{
+					{FailingResources: []*provider.FinopsPolicyFailingResource{{CauseAddress: "r1"}}},
+				},
+			},
+		},
+	}
+
+	diff := computeRunDiff(current, prev)
+	if diff.newResources != 2 {
+		t.Errorf("expected 2 new resources, got %d", diff.newResources)
+	}
+	if diff.newIssues != 1 {
+		t.Errorf("expected 1 new issue, got %d", diff.newIssues)
+	}
+	if diff.changedResources != 0 {
+		t.Errorf("expected 0 changed resources, got %d", diff.changedResources)
+	}
+	if diff.existingIssues != 0 {
+		t.Errorf("expected 0 existing issues, got %d", diff.existingIssues)
+	}
+}
+
+func TestComputeRunDiff_ExistingIssues(t *testing.T) {
+	prev := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				Resources: []*provider.Resource{
+					{Name: "r1", Metadata: &provider.ResourceMetadata{DeepChecksum: "aaa"}},
+				},
+				FinopsResults: []*provider.FinopsPolicyResult{
+					{PolicySlug: "pol", FailingResources: []*provider.FinopsPolicyFailingResource{{CauseAddress: "r1"}}},
+				},
+				TagPolicyResults: []goprotoevent.TaggingPolicyResult{
+					{TagPolicyID: "tp", FailingResources: []goprotoevent.TagPolicyResultResource{{Address: "r1"}}},
+				},
+			},
+		},
+	}
+	current := &config.DirectoryResult{
+		Projects: []pkgscanner.ProjectResult{
+			{
+				Name: "p",
+				Resources: []*provider.Resource{
+					{Name: "r1", Metadata: &provider.ResourceMetadata{DeepChecksum: "aaa"}},
+				},
+				FinopsResults: []*provider.FinopsPolicyResult{
+					{PolicySlug: "pol", FailingResources: []*provider.FinopsPolicyFailingResource{{CauseAddress: "r1"}}},
+				},
+				TagPolicyResults: []goprotoevent.TaggingPolicyResult{
+					{TagPolicyID: "tp", FailingResources: []goprotoevent.TagPolicyResultResource{{Address: "r1"}}},
+				},
+			},
+		},
+	}
+
+	diff := computeRunDiff(current, prev)
+	if diff.existingIssues != 2 {
+		t.Errorf("expected 2 existing issues, got %d", diff.existingIssues)
+	}
+	if diff.newIssues != 0 {
+		t.Errorf("expected 0 new issues, got %d", diff.newIssues)
+	}
+	if diff.changedResources != 0 {
+		t.Errorf("expected 0 changed resources, got %d", diff.changedResources)
+	}
+}
+
+// toMap converts the variadic key-value pairs into a map for easier assertions.
+func toMap(t *testing.T, kvs []interface{}) map[string]interface{} {
+	t.Helper()
+	if len(kvs)%2 != 0 {
+		t.Fatalf("expected even number of key-value pairs, got %d", len(kvs))
+	}
+	m := make(map[string]interface{}, len(kvs)/2)
+	for i := 0; i < len(kvs); i += 2 {
+		key, ok := kvs[i].(string)
+		if !ok {
+			t.Fatalf("expected string key at index %d, got %T", i, kvs[i])
+		}
+		m[key] = kvs[i+1]
+	}
+	return m
+}
+
+// assertEq checks that m[key] equals want.
+func assertEq(t *testing.T, m map[string]interface{}, key string, want interface{}) {
+	t.Helper()
+	got, ok := m[key]
+	if !ok {
+		t.Errorf("key %q not found in event metadata", key)
+		return
+	}
+	if got != want {
+		t.Errorf("key %q: got %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}

--- a/tools/scanner/internal/commands/scan.go
+++ b/tools/scanner/internal/commands/scan.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/infracost/actions/tools/scanner/internal/api"
 	"github.com/infracost/actions/tools/scanner/internal/config"
@@ -41,6 +42,7 @@ func Scan(cfg *config.Config) *cobra.Command {
 
 func scan(cfg *config.Config, args *scanArgs) error {
 	ctx := context.Background()
+	startTime := time.Now()
 
 	if len(cfg.Auth.AuthenticationToken) == 0 {
 		return fmt.Errorf("authentication token is required: set INFRACOST_CLI_AUTHENTICATION_TOKEN")
@@ -108,6 +110,9 @@ func scan(cfg *config.Config, args *scanArgs) error {
 			return fmt.Errorf("failed to upload run to dashboard: %w", err)
 		}
 	}
+
+	eventsClient := cfg.Events.Client(httpClient)
+	trackRun(ctx, eventsClient, result, nil, time.Since(startTime).Seconds(), "upload")
 
 	return nil
 }

--- a/tools/scanner/internal/commands/scan_integration_test.go
+++ b/tools/scanner/internal/commands/scan_integration_test.go
@@ -12,6 +12,24 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// setupScanEventsMocks configures the events mock to expect a single
+// infracost-run push and captures the metadata for verification.
+func setupScanEventsMocks(m *testingconfig.Mocks) *map[string]interface{} {
+	captured := make(map[string]interface{})
+	m.Events.EXPECT().
+		Push(mock.Anything, "infracost-run", mock.Anything).
+		Run(func(_ context.Context, _ string, extra ...interface{}) {
+			for i := 0; i < len(extra); i += 2 {
+				if key, ok := extra[i].(string); ok {
+					captured[key] = extra[i+1]
+				}
+			}
+		}).
+		Return().
+		Once()
+	return &captured
+}
+
 func runScan(t *testing.T, cfg *config.Config, path string) error {
 	t.Helper()
 	return scan(cfg, &scanArgs{path: path})
@@ -24,6 +42,9 @@ func TestScan_BasicUpload(t *testing.T) {
 	m.Dashboard.EXPECT().
 		RunParameters(mock.Anything, mock.Anything, mock.Anything).
 		Return(emptyRunParams(), nil)
+
+	runEvent := setupScanEventsMocks(m)
+	_ = runEvent // used below after scan
 
 	m.Dashboard.EXPECT().
 		AddRun(mock.Anything, mock.Anything).
@@ -56,6 +77,14 @@ func TestScan_BasicUpload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scan() returned error: %v", err)
 	}
+
+	env := *runEvent
+	if env["outputFormat"] != "upload" {
+		t.Errorf("expected outputFormat 'upload', got %v", env["outputFormat"])
+	}
+	if env["totalResources"] == nil || env["totalResources"].(int) == 0 {
+		t.Error("expected non-zero totalResources in infracost-run event")
+	}
 }
 
 func TestScan_DashboardDisabled(t *testing.T) {
@@ -68,6 +97,7 @@ func TestScan_DashboardDisabled(t *testing.T) {
 		Return(emptyRunParams(), nil)
 
 	// AddRun should NOT be called when dashboard is disabled.
+	setupScanEventsMocks(m)
 
 	err := runScan(t, &cfg, filepath.Join(testdataDir(), "basic", "head"))
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `infracost-run` event tracking to both `scan` and `diff` commands with resource counts, usage stats, and diff metrics
- Add `cloud-issue-fixed` event tracking to `diff` command for finops and tagging policy violations resolved between base and head
- Add unit tests for all event tracking logic and wire events mock into existing integration tests