### PR TITLE
fix: match dashboard diff calculation and drop ProjectResult.Resources

### DIFF
--- a/tools/scanner/go.mod
+++ b/tools/scanner/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/infracost/config v0.5.0
 	github.com/infracost/go-proto v1.13.0
 	github.com/infracost/proto v1.34.0
-	github.com/infracost/vcs v0.2.0
+	github.com/infracost/vcs v0.2.1-0.20260430090745-e372124deb26
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9

--- a/tools/scanner/go.mod
+++ b/tools/scanner/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/infracost/config v0.5.0
 	github.com/infracost/go-proto v1.13.0
 	github.com/infracost/proto v1.34.0
-	github.com/infracost/vcs v0.2.1-0.20260430090745-e372124deb26
+	github.com/infracost/vcs v0.2.1
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9

--- a/tools/scanner/go.sum
+++ b/tools/scanner/go.sum
@@ -68,6 +68,10 @@ github.com/infracost/proto v1.34.0 h1:zkp3C8YCozE6hZ8bP00dk4jQE2c0/QZDZjkII08k9/
 github.com/infracost/proto v1.34.0/go.mod h1:Z8vPWBWblwJlw+/ksO+BtsXwf9NiOcSTWx0WRWNbfUA=
 github.com/infracost/vcs v0.2.0 h1:KMiQRqUD4merbPPARcPBp0muLiqJeTCoDBIMpVJEhT4=
 github.com/infracost/vcs v0.2.0/go.mod h1:150HZa7bHoApUtq05T4OSuptislttY0Xrhv0LaqLbFU=
+github.com/infracost/vcs v0.2.1-0.20260429160835-ae8ad06125c9 h1:cTTTA3v/LwIdHrQt6JIGwQaRWH35lrwu17lIriBP/0U=
+github.com/infracost/vcs v0.2.1-0.20260429160835-ae8ad06125c9/go.mod h1:150HZa7bHoApUtq05T4OSuptislttY0Xrhv0LaqLbFU=
+github.com/infracost/vcs v0.2.1-0.20260430090745-e372124deb26 h1:2ZGNgFTeNeLvJb6euvCjdDf/aR2m51H60ei65XiiwnI=
+github.com/infracost/vcs v0.2.1-0.20260430090745-e372124deb26/go.mod h1:150HZa7bHoApUtq05T4OSuptislttY0Xrhv0LaqLbFU=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/tools/scanner/go.sum
+++ b/tools/scanner/go.sum
@@ -72,6 +72,8 @@ github.com/infracost/vcs v0.2.1-0.20260429160835-ae8ad06125c9 h1:cTTTA3v/LwIdHrQ
 github.com/infracost/vcs v0.2.1-0.20260429160835-ae8ad06125c9/go.mod h1:150HZa7bHoApUtq05T4OSuptislttY0Xrhv0LaqLbFU=
 github.com/infracost/vcs v0.2.1-0.20260430090745-e372124deb26 h1:2ZGNgFTeNeLvJb6euvCjdDf/aR2m51H60ei65XiiwnI=
 github.com/infracost/vcs v0.2.1-0.20260430090745-e372124deb26/go.mod h1:150HZa7bHoApUtq05T4OSuptislttY0Xrhv0LaqLbFU=
+github.com/infracost/vcs v0.2.1 h1:Gj2+S0ei9LtTYdtaXKGJcMDn+YziMZK8sa4oLD9jQN0=
+github.com/infracost/vcs v0.2.1/go.mod h1:150HZa7bHoApUtq05T4OSuptislttY0Xrhv0LaqLbFU=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/tools/scanner/internal/config/comment.go
+++ b/tools/scanner/internal/config/comment.go
@@ -75,7 +75,6 @@ func BuildCommentData(opts CommentDataOptions) comment.Data {
 			pr.Breakdown = buildCostBreakdown(head.Resources)
 			pr.TotalMonthlyCost = head.TotalMonthlyCost
 			pr.TotalMonthlyUsageCost = totalMonthlyUsageCostFromResources(head.Resources)
-			pr.Resources = head.Resources
 			pr.Diagnostics = head.Diagnostics
 
 			if head.Config != nil {
@@ -280,6 +279,11 @@ func convertCostComponent(c *provider.CostComponent) comment.BreakdownCostCompon
 }
 
 // diffCostBreakdown computes the difference between two cost breakdowns.
+// It mirrors the runner's pricing/schema CalculateDiff: a resource is included
+// in the diff when any cost component, sub-resource, or resource-level cost
+// changed (including resources that were added or removed). A resource whose
+// total monthly cost happens to be unchanged but whose components shifted is
+// still considered changed, matching the dashboard's hasDiff criterion.
 func diffCostBreakdown(past, current *comment.CostBreakdown) *comment.CostBreakdown {
 	if past == nil {
 		return current
@@ -289,40 +293,161 @@ func diffCostBreakdown(past, current *comment.CostBreakdown) *comment.CostBreakd
 	}
 
 	diff := &comment.CostBreakdown{
-		TotalMonthlyCost: current.TotalMonthlyCost.Sub(past.TotalMonthlyCost),
+		TotalMonthlyCost: orZero(current.TotalMonthlyCost).Sub(orZero(past.TotalMonthlyCost)),
 	}
 
-	// Build map of past resources by name for matching.
-	pastByName := make(map[string]*comment.BreakdownResource, len(past.Resources))
-	for i := range past.Resources {
-		pastByName[past.Resources[i].Name] = &past.Resources[i]
-	}
+	pastByName := indexBreakdownResources(past.Resources)
+	currentByName := indexBreakdownResources(current.Resources)
 
+	seen := make(map[string]bool, len(past.Resources)+len(current.Resources))
+	// Walk past first to keep removed/changed resources in past order, then
+	// append any current-only (added) resources in current order.
+	for _, r := range past.Resources {
+		if seen[r.Name] {
+			continue
+		}
+		seen[r.Name] = true
+		if changed, dr := diffResource(pastByName[r.Name], currentByName[r.Name]); changed {
+			diff.Resources = append(diff.Resources, dr)
+		}
+	}
 	for _, r := range current.Resources {
-		if pastR, ok := pastByName[r.Name]; ok {
-			costDiff := orZero(r.MonthlyCost).Sub(orZero(pastR.MonthlyCost))
-			if !costDiff.IsZero() {
-				diff.Resources = append(diff.Resources, comment.BreakdownResource{
-					Name:        r.Name,
-					MonthlyCost: costDiff,
-				})
-			}
-			delete(pastByName, r.Name)
-		} else {
-			// New resource.
-			diff.Resources = append(diff.Resources, r)
+		if seen[r.Name] {
+			continue
+		}
+		seen[r.Name] = true
+		if changed, dr := diffResource(pastByName[r.Name], currentByName[r.Name]); changed {
+			diff.Resources = append(diff.Resources, dr)
 		}
 	}
 
-	// Remaining past resources were removed.
-	for _, r := range pastByName {
-		diff.Resources = append(diff.Resources, comment.BreakdownResource{
-			Name:        r.Name,
-			MonthlyCost: orZero(r.MonthlyCost).Mul(rat.New(-1)),
-		})
+	return diff
+}
+
+func indexBreakdownResources(resources []comment.BreakdownResource) map[string]*comment.BreakdownResource {
+	m := make(map[string]*comment.BreakdownResource, len(resources))
+	for i := range resources {
+		m[resources[i].Name] = &resources[i]
+	}
+	return m
+}
+
+// diffResource recursively compares a past and current breakdown resource and
+// returns whether they differ along with a synthesised "diff" resource whose
+// fields hold the deltas (old=0 for adds, current=0 for removes).
+func diffResource(past, current *comment.BreakdownResource) (bool, comment.BreakdownResource) {
+	pastSafe := past
+	if pastSafe == nil {
+		pastSafe = &comment.BreakdownResource{}
+	}
+	currentSafe := current
+	if currentSafe == nil {
+		currentSafe = &comment.BreakdownResource{}
 	}
 
-	return diff
+	name := currentSafe.Name
+	if name == "" {
+		name = pastSafe.Name
+	}
+
+	monthlyCostDiff := orZero(currentSafe.MonthlyCost).Sub(orZero(pastSafe.MonthlyCost))
+	out := comment.BreakdownResource{
+		Name:        name,
+		MonthlyCost: monthlyCostDiff,
+	}
+
+	changed := past == nil || current == nil || !monthlyCostDiff.IsZero()
+
+	pastSubs := indexBreakdownResources(pastSafe.SubResources)
+	currentSubs := indexBreakdownResources(currentSafe.SubResources)
+	seenSub := make(map[string]bool, len(pastSafe.SubResources)+len(currentSafe.SubResources))
+	for _, sr := range pastSafe.SubResources {
+		if seenSub[sr.Name] {
+			continue
+		}
+		seenSub[sr.Name] = true
+		if subChanged, sd := diffResource(pastSubs[sr.Name], currentSubs[sr.Name]); subChanged {
+			out.SubResources = append(out.SubResources, sd)
+			changed = true
+		}
+	}
+	for _, sr := range currentSafe.SubResources {
+		if seenSub[sr.Name] {
+			continue
+		}
+		seenSub[sr.Name] = true
+		if subChanged, sd := diffResource(pastSubs[sr.Name], currentSubs[sr.Name]); subChanged {
+			out.SubResources = append(out.SubResources, sd)
+			changed = true
+		}
+	}
+
+	if ccChanged, ccDiff := diffCostComponents(pastSafe.CostComponents, currentSafe.CostComponents); ccChanged {
+		out.CostComponents = ccDiff
+		changed = true
+	}
+
+	return changed, out
+}
+
+func diffCostComponents(past, current []comment.BreakdownCostComponent) (bool, []comment.BreakdownCostComponent) {
+	currentByName := make(map[string]*comment.BreakdownCostComponent, len(current))
+	for i := range current {
+		currentByName[current[i].Name] = &current[i]
+	}
+
+	var out []comment.BreakdownCostComponent
+	changed := false
+	seen := make(map[string]bool, len(past))
+	for i := range past {
+		seen[past[i].Name] = true
+		if cChanged, cd := diffCostComponent(&past[i], currentByName[past[i].Name]); cChanged {
+			out = append(out, cd)
+			changed = true
+		}
+	}
+	for i := range current {
+		if seen[current[i].Name] {
+			continue
+		}
+		if cChanged, cd := diffCostComponent(nil, &current[i]); cChanged {
+			out = append(out, cd)
+			changed = true
+		}
+	}
+	return changed, out
+}
+
+func diffCostComponent(past, current *comment.BreakdownCostComponent) (bool, comment.BreakdownCostComponent) {
+	pastSafe := past
+	if pastSafe == nil {
+		pastSafe = &comment.BreakdownCostComponent{}
+	}
+	currentSafe := current
+	if currentSafe == nil {
+		currentSafe = &comment.BreakdownCostComponent{}
+	}
+
+	base := current
+	if base == nil {
+		base = past
+	}
+
+	priceDiff := orZero(currentSafe.Price).Sub(orZero(pastSafe.Price))
+	qtyDiff := orZero(currentSafe.MonthlyQuantity).Sub(orZero(pastSafe.MonthlyQuantity))
+	costDiff := orZero(currentSafe.MonthlyCost).Sub(orZero(pastSafe.MonthlyCost))
+
+	out := comment.BreakdownCostComponent{
+		Name:            base.Name,
+		Unit:            base.Unit,
+		UsageBased:      base.UsageBased,
+		Price:           priceDiff,
+		MonthlyQuantity: qtyDiff,
+		MonthlyCost:     costDiff,
+	}
+
+	changed := !priceDiff.IsZero() || !qtyDiff.IsZero() || !costDiff.IsZero()
+	return changed, out
 }
 
 // totalMonthlyUsageCostFromResources sums only usage-based cost components

--- a/tools/scanner/internal/config/comment_test.go
+++ b/tools/scanner/internal/config/comment_test.go
@@ -348,6 +348,46 @@ func TestDiffCostBreakdown(t *testing.T) {
 			wantTotalDiff:     "-10",
 			wantDiffResources: 3, // a changed, c new, b removed
 		},
+		{
+			name: "components shift but total cost unchanged",
+			past: mkBreakdown(comment.BreakdownResource{
+				Name:        "a",
+				MonthlyCost: rat.New(10),
+				CostComponents: []comment.BreakdownCostComponent{
+					{Name: "x", MonthlyCost: rat.New(7)},
+					{Name: "y", MonthlyCost: rat.New(3)},
+				},
+			}),
+			current: mkBreakdown(comment.BreakdownResource{
+				Name:        "a",
+				MonthlyCost: rat.New(10),
+				CostComponents: []comment.BreakdownCostComponent{
+					{Name: "x", MonthlyCost: rat.New(4)},
+					{Name: "y", MonthlyCost: rat.New(6)},
+				},
+			}),
+			wantTotalDiff:     "0",
+			wantDiffResources: 1,
+		},
+		{
+			name: "sub-resource cost change",
+			past: mkBreakdown(comment.BreakdownResource{
+				Name:        "a",
+				MonthlyCost: rat.New(10),
+				SubResources: []comment.BreakdownResource{
+					{Name: "a.disk", MonthlyCost: rat.New(10)},
+				},
+			}),
+			current: mkBreakdown(comment.BreakdownResource{
+				Name:        "a",
+				MonthlyCost: rat.New(15),
+				SubResources: []comment.BreakdownResource{
+					{Name: "a.disk", MonthlyCost: rat.New(15)},
+				},
+			}),
+			wantTotalDiff:     "5",
+			wantDiffResources: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Companion to infracost/vcs#6. Updates the scanner caller to:

- Match the dashboard's diff calculation. `diffCostBreakdown` is now a recursive comparison: a resource lands in the diff when **any** of its cost components, sub-resources, or total monthly cost differs (adds/removes always included). Previously we only compared total monthly cost, so a resource with components that shifted but netted to the same total was excluded — same edge case the dashboard handles via cost-component comparison.
- Drop the now-unused `pr.Resources = head.Resources` assignment. The corresponding field was removed from `comment.ProjectResult` in vcs (hasDiff now reads from `DiffBreakdown`, hasUnsupported from `Summary.TotalUnsupportedResources`).
- Bump infracost/vcs to pick up matching comment-formatting fixes: thousand separators, `-$X` negative-currency placement, carbon verb conjugation (`avoids`/`emits`), distance precision (`335.7 km`), deterministic budget tag ordering, and HTML block separation in the template.

## ⚠️ Blocked on infracost/vcs#6

This PR currently pins to a pseudo-version of the unmerged vcs branch:

```
github.com/infracost/vcs v0.2.1-0.20260429160835-ae8ad06125c9
```

Before merging:
1. Wait for infracost/vcs#6 to be merged.
2. Tag and release a new version of vcs.
3. Update `tools/scanner/go.mod` to the released version (`go get github.com/infracost/vcs@<tag>`).
4. Verify build/tests still pass.