### PR TITLE
feat(scanner): skip dashboard uploads when org cloud is disabled

### DIFF
--- a/tools/scanner/internal/api/dashboard/client.go
+++ b/tools/scanner/internal/api/dashboard/client.go
@@ -14,6 +14,7 @@ import (
 type RunParameters struct {
 	OrganizationID   string `json:"organizationId"`
 	OrganizationSlug string `json:"organizationSlug"`
+	CloudEnabled     bool   `json:"cloudEnabled"`
 	RepositoryID     string `json:"repositoryId"`
 	RepositoryName   string `json:"repositoryName"`
 
@@ -265,6 +266,7 @@ func (c *client) RunParameters(ctx context.Context, repoURL, branchName string) 
   runParameters(repoUrl: $repoUrl, branchName: $branchName) {
     organizationId
     organizationSlug
+    cloudEnabled
     repositoryId
     repositoryName
     usageDefaults

--- a/tools/scanner/internal/commands/diff.go
+++ b/tools/scanner/internal/commands/diff.go
@@ -144,9 +144,11 @@ func diff(cfg *config.Config, args *diffArgs, vcsClient vcs.VCS, results *ScanRe
 		PipelineRunID:     args.pipelineRunID,
 	}
 
+	uploadEnabled := !cfg.DisableDashboard && runParams.CloudEnabled
+
 	baseResult, err := cfg.ScanDirectory(ctx, args.basePath, token.AccessToken, runParams, nil, args.project, baseBranch)
 	if err != nil {
-		if !cfg.DisableDashboard {
+		if uploadEnabled {
 			errInput := config.BuildErrorRunInput(runOpts, diagnostic.ErrorCodeCLIBreakdownError, "Failed to scan base branch", err.Error())
 			_, _ = dashboardClient.AddRun(ctx, errInput)
 		}
@@ -166,7 +168,7 @@ func diff(cfg *config.Config, args *diffArgs, vcsClient vcs.VCS, results *ScanRe
 
 	headResult, err := cfg.ScanDirectory(ctx, args.headPath, token.AccessToken, runParams, previousAddresses, args.project, baseBranch)
 	if err != nil {
-		if !cfg.DisableDashboard {
+		if uploadEnabled {
 			errInput := config.BuildErrorRunInput(runOpts, diagnostic.ErrorCodeCLIBreakdownError, "Failed to scan head branch", err.Error())
 			_, _ = dashboardClient.AddRun(ctx, errInput)
 		}
@@ -204,7 +206,7 @@ func diff(cfg *config.Config, args *diffArgs, vcsClient vcs.VCS, results *ScanRe
 	// Upload run results to the dashboard and set the cloud URL in the comment.
 	// TODO: on failure, post the comment without the cloud URL and include a
 	// message explaining that this run could not be uploaded to the dashboard.
-	if !cfg.DisableDashboard {
+	if uploadEnabled {
 		runOpts.BaseResult = baseResult
 		runOpts.HeadResult = headResult
 		runOpts.GuardrailResults = guardrailResults

--- a/tools/scanner/internal/commands/diff_integration_test.go
+++ b/tools/scanner/internal/commands/diff_integration_test.go
@@ -40,6 +40,7 @@ func emptyRunParams() dashboard.RunParameters {
 	return dashboard.RunParameters{
 		OrganizationID:   "test-org-id",
 		OrganizationSlug: "test-org",
+		CloudEnabled:     true,
 		RepositoryID:     "test-repo-id",
 		RepositoryName:   "test-repo",
 	}

--- a/tools/scanner/internal/commands/scan.go
+++ b/tools/scanner/internal/commands/scan.go
@@ -89,16 +89,18 @@ func scan(cfg *config.Config, args *scanArgs) error {
 		UsageAPIEnabled: runParams.UsageDefaults != nil && len(runParams.UsageDefaults.Resources) > 0,
 	}
 
+	uploadEnabled := !cfg.DisableDashboard && runParams.CloudEnabled
+
 	result, err := cfg.ScanDirectory(ctx, args.path, token.AccessToken, runParams, nil, args.project, branch)
 	if err != nil {
-		if !cfg.DisableDashboard {
+		if uploadEnabled {
 			errInput := config.BuildErrorRunInput(runOpts, diagnostic.ErrorCodeCLIBreakdownError, "Failed to scan", err.Error())
 			_, _ = dashboardClient.AddRun(ctx, errInput)
 		}
 		return fmt.Errorf("failed to scan path: %w", err)
 	}
 
-	if !cfg.DisableDashboard {
+	if uploadEnabled {
 		runOpts.HeadResult = result
 		runOpts.Currency = result.Currency
 		runOpts.UsageFilePath = result.UsageFilePath

--- a/tools/scanner/internal/commands/status.go
+++ b/tools/scanner/internal/commands/status.go
@@ -61,5 +61,18 @@ func updatePullRequestStatus(cfg *config.Config, repoURL string, prNumber int, s
 
 	httpClient := api.Client(ctx, tokenSource, cfg.OrgID)
 	dashboardClient := cfg.Dashboard.Client(httpClient)
+
+	if cfg.DisableDashboard {
+		return nil
+	}
+
+	runParams, err := dashboardClient.RunParameters(ctx, repoURL, "")
+	if err != nil {
+		return fmt.Errorf("failed to fetch run parameters: %w", err)
+	}
+	if !runParams.CloudEnabled {
+		return nil
+	}
+
 	return dashboardClient.UpdatePullRequestStatus(ctx, prURL, status)
 }

--- a/tools/scanner/internal/config/scan.go
+++ b/tools/scanner/internal/config/scan.go
@@ -43,6 +43,7 @@ type DirectoryResult struct {
 type ParsedRunParameters struct {
 	OrganizationID   string
 	OrganizationSlug string
+	CloudEnabled     bool
 	RepositoryID     string
 	RepositoryName   string
 
@@ -58,6 +59,7 @@ func ParseRunParameters(raw dashboard.RunParameters) (*ParsedRunParameters, erro
 	parsed := &ParsedRunParameters{
 		OrganizationID:   raw.OrganizationID,
 		OrganizationSlug: raw.OrganizationSlug,
+		CloudEnabled:     raw.CloudEnabled,
 		RepositoryID:     raw.RepositoryID,
 		RepositoryName:   raw.RepositoryName,
 	}


### PR DESCRIPTION
> [!IMPORTANT]
> Must be merged after infracost/dashboard#5076 — depends on the `cloudEnabled` field added there.

## Summary

- Reads the new `cloudEnabled` field from the `runParameters` GraphQL query (added in infracost/dashboard#5076) and gates all dashboard writes on it.
- When the org-level *"Monitor all pull requests from this organization's API key in CI/CD"* toggle is off, the scanner now skips `addRun` (in both `scan` and `diff`, including the error-run uploads) and `updatePullRequestStatus` (in `status`) instead of making the call anyway.
- The `status` command now fetches `runParameters` since it previously had no reason to — branch is passed as empty string (the GraphQL query treats `branchName` as optional and branch isn't applicable to a status update).
- `emptyRunParams()` in the integration tests now sets `CloudEnabled: true` so existing assertions that `AddRun` is called continue to hold; the `DashboardDisabled` tests still skip via `cfg.DisableDashboard = true`.