### PR TITLE
fix: use env vars in actions rather than in script evaluation

### DIFF
--- a/.github/workflows/examples_test.yml
+++ b/.github/workflows/examples_test.yml
@@ -46,10 +46,12 @@ jobs:
                           --compare-to=/tmp/infracost-base.json \
                           --out-file=/tmp/infracost.json
       - name: Post Infracost comment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |-
           infracost comment github --path=/tmp/infracost.json \
-          --repo=$GITHUB_REPOSITORY \
-          --github-token=${{ github.token }} \
+          --repo="$GITHUB_REPOSITORY" \
+          --github-token="$GITHUB_TOKEN" \
           --pull-request=1 \
           --behavior=update \
           --dry-run true \

--- a/.github/workflows/scanner_release.yml
+++ b/.github/workflows/scanner_release.yml
@@ -23,13 +23,29 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
       - id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RAW_VERSION="${{ github.event.inputs.version }}"
+          write_output() {
+            local name="$1"
+            local value="$2"
+            local delimiter
+            delimiter="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}"
+
+            {
+              printf '%s<<%s\n' "$name" "$delimiter"
+              printf '%s\n' "$value"
+              printf '%s\n' "$delimiter"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RAW_VERSION="$INPUT_VERSION"
           else
             RAW_VERSION="${GITHUB_REF#refs/tags/scanner/v}"
           fi
-          echo "VERSION=${RAW_VERSION#v}" >> $GITHUB_OUTPUT
+          write_output "VERSION" "${RAW_VERSION#v}"
 
   draft-release:
     runs-on: ubuntu-24.04
@@ -42,11 +58,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: scanner/v${{ needs.version.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if gh release view "$VERSION" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "EXISTS=true" >> $GITHUB_OUTPUT
+          if gh release view "$VERSION" --repo "$REPOSITORY" >/dev/null 2>&1; then
+            echo "EXISTS=true" >> "$GITHUB_OUTPUT"
           else
-            echo "EXISTS=false" >> $GITHUB_OUTPUT
+            echo "EXISTS=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create draft release
@@ -54,10 +71,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: scanner/v${{ needs.version.outputs.version }}
+          RELEASE_VERSION: ${{ needs.version.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh release create "$VERSION" \
-            --repo "${{ github.repository }}" \
-            --title "Scanner ${{ needs.version.outputs.version }}" \
+            --repo "$REPOSITORY" \
+            --title "Scanner $RELEASE_VERSION" \
             --draft
 
       - name: Reset to draft
@@ -65,9 +84,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: scanner/v${{ needs.version.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh release edit "$VERSION" \
-            --repo "${{ github.repository }}" \
+            --repo "$REPOSITORY" \
             --draft
 
   build-and-release:
@@ -118,9 +138,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: scanner/v${{ needs.version.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh release upload "$VERSION" ./dist/* \
-            --repo "${{ github.repository }}" \
+            --repo "$REPOSITORY" \
             --clobber
 
   publish-release:
@@ -133,7 +154,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: scanner/v${{ needs.version.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh release edit "$VERSION" \
-            --repo "${{ github.repository }}" \
+            --repo "$REPOSITORY" \
             --draft=false

--- a/.github/workflows/setup_test.yml
+++ b/.github/workflows/setup_test.yml
@@ -33,16 +33,19 @@ jobs:
           pricing-api-endpoint: https://test.test
 
       - name: Get expected version
+        env:
+          MATRIX_VERSION: ${{ matrix.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ matrix.version }}" = "<0.9.11" ]; then
+          if [ "$MATRIX_VERSION" = "<0.9.11" ]; then
             export INFRACOST_EXPECTED_VERSION=v0.9.10
-          elif [ "${{ matrix.version }}" = "0.9.12" ]; then
+          elif [ "$MATRIX_VERSION" = "0.9.12" ]; then
             export INFRACOST_EXPECTED_VERSION=v0.9.12
           else
-            export INFRACOST_EXPECTED_VERSION=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/infracost/infracost/releases/latest | jq -r .name )
+            export INFRACOST_EXPECTED_VERSION=$(curl --header "authorization: Bearer $GH_TOKEN" https://api.github.com/repos/infracost/infracost/releases/latest | jq -r .name )
           fi
-          echo "Expected version for ${{ matrix.version }}: $INFRACOST_EXPECTED_VERSION"
-          echo "INFRACOST_EXPECTED_VERSION=Infracost $INFRACOST_EXPECTED_VERSION" >> $GITHUB_ENV
+          echo "Expected version for $MATRIX_VERSION: $INFRACOST_EXPECTED_VERSION"
+          echo "INFRACOST_EXPECTED_VERSION=Infracost $INFRACOST_EXPECTED_VERSION" >> "$GITHUB_ENV"
       - name: Capture infracost version installed
         run: |
           echo "INFRACOST_VERSION_INSTALLED=$( infracost --version )" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ runs:
 
     - name: Post Infracost comment
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        COMMENT_BEHAVIOR: ${{ inputs.behavior }}
       run: |
         # Posts a comment to the PR using the 'update' behavior.
         # This creates a single comment and updates it. The "quietest" option.
@@ -64,7 +68,7 @@ runs:
         #   new - Create a new cost estimate comment on every push.
         # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
         infracost comment github --path=/tmp/infracost.json \
-                                 --repo=$GITHUB_REPOSITORY \
-                                 --github-token=${{github.token}} \
-                                 --pull-request=${{github.event.pull_request.number}} \
-                                 --behavior=${{inputs.behavior}}
+                                 --repo="$GITHUB_REPOSITORY" \
+                                 --github-token="$GITHUB_TOKEN" \
+                                 --pull-request="$PULL_REQUEST_NUMBER" \
+                                 --behavior="$COMMENT_BEHAVIOR"

--- a/diff/action.yml
+++ b/diff/action.yml
@@ -48,6 +48,19 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         VERSION: ${{ inputs.version }}
       run: |
+        write_output() {
+          local name="$1"
+          local value="$2"
+          local delimiter
+          delimiter="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}"
+
+          {
+            printf '%s<<%s\n' "$name" "$delimiter"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+        }
+
         if [ "$VERSION" = "latest" ]; then
           RELEASE=$(gh release list --repo "infracost/actions" --limit 50 --json tagName --jq '[.[] | select(.tagName | startswith("scanner/v"))][0].tagName')
           if [ -z "$RELEASE" ]; then
@@ -56,8 +69,8 @@ runs:
           fi
           VERSION="${RELEASE#scanner/v}"
         fi
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "tag=scanner/v${VERSION}" >> $GITHUB_OUTPUT
+        write_output "version" "$VERSION"
+        write_output "tag" "scanner/v${VERSION}"
 
     - name: Download scanner
       shell: bash
@@ -89,12 +102,42 @@ runs:
     - name: Derive context
       id: context
       shell: bash
+      env:
+        INPUT_GITHUB_OWNER: ${{ inputs.github-owner }}
+        INPUT_GITHUB_REPO: ${{ inputs.github-repo }}
+        INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        INPUT_REPO_URL: ${{ inputs.repo-url }}
+        INPUT_PR_STATUS: ${{ inputs.pr-status }}
+        INPUT_BASE_PATH: ${{ inputs.base-path }}
+        INPUT_HEAD_PATH: ${{ inputs.head-path }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        EVENT_PR_TITLE: ${{ github.event.pull_request.title }}
+        EVENT_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        EVENT_PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_ACTION: ${{ github.event.action }}
+        EVENT_PR_MERGED: ${{ github.event.pull_request.merged }}
       run: |
-        OWNER="${{ inputs.github-owner }}"
-        REPO="${{ inputs.github-repo }}"
-        PR="${{ inputs.pr-number }}"
-        REPO_URL="${{ inputs.repo-url }}"
-        PR_STATUS="${{ inputs.pr-status }}"
+        set -euo pipefail
+
+        write_output() {
+          local name="$1"
+          local value="$2"
+          local delimiter
+          delimiter="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}"
+
+          {
+            printf '%s<<%s\n' "$name" "$delimiter"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+        }
+
+        OWNER="$INPUT_GITHUB_OWNER"
+        REPO="$INPUT_GITHUB_REPO"
+        PR="$INPUT_PR_NUMBER"
+        REPO_URL="$INPUT_REPO_URL"
+        PR_STATUS="$INPUT_PR_STATUS"
 
         if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
           OWNER="${GITHUB_REPOSITORY_OWNER}"
@@ -102,7 +145,7 @@ runs:
         fi
 
         if [ -z "$PR" ]; then
-          PR="${{ github.event.pull_request.number }}"
+          PR="$EVENT_PR_NUMBER"
         fi
 
         if [ -z "$PR" ] || [ "$PR" = "0" ]; then
@@ -114,20 +157,23 @@ runs:
           REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
         fi
 
-        PR_TITLE="${{ github.event.pull_request.title }}"
-        PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-        PR_LABELS=$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}' | jq -r 'join(",")')
+        PR_TITLE="$EVENT_PR_TITLE"
+        PR_AUTHOR="$EVENT_PR_AUTHOR"
+        PR_LABELS=""
+        if [ -n "$EVENT_PR_LABELS_JSON" ]; then
+          PR_LABELS=$(jq -r 'if type == "array" then join(",") else "" end' <<< "$EVENT_PR_LABELS_JSON")
+        fi
         PIPELINE_RUN_ID="${GITHUB_RUN_ID}"
 
         # Determine the action mode and PR status from the event context
         # if not explicitly provided.
         MODE="scan"
         if [ -z "$PR_STATUS" ]; then
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            case "${{ github.event.action }}" in
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            case "$EVENT_ACTION" in
               closed)
                 MODE="status-only"
-                if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+                if [ "$EVENT_PR_MERGED" = "true" ]; then
                   PR_STATUS="MERGED"
                 else
                   PR_STATUS="CLOSED"
@@ -141,21 +187,21 @@ runs:
         else
           # User provided an explicit status. If base-path and head-path
           # are not set, skip scanning and only update the status.
-          if [ -z "${{ inputs.base-path }}" ] || [ -z "${{ inputs.head-path }}" ]; then
+          if [ -z "$INPUT_BASE_PATH" ] || [ -z "$INPUT_HEAD_PATH" ]; then
             MODE="status-only"
           fi
         fi
 
-        echo "owner=${OWNER}" >> $GITHUB_OUTPUT
-        echo "repo=${REPO}" >> $GITHUB_OUTPUT
-        echo "pr=${PR}" >> $GITHUB_OUTPUT
-        echo "repo-url=${REPO_URL}" >> $GITHUB_OUTPUT
-        echo "pr-title=${PR_TITLE}" >> $GITHUB_OUTPUT
-        echo "pr-author=${PR_AUTHOR}" >> $GITHUB_OUTPUT
-        echo "pr-labels=${PR_LABELS}" >> $GITHUB_OUTPUT
-        echo "pipeline-run-id=${PIPELINE_RUN_ID}" >> $GITHUB_OUTPUT
-        echo "mode=${MODE}" >> $GITHUB_OUTPUT
-        echo "pr-status=${PR_STATUS}" >> $GITHUB_OUTPUT
+        write_output "owner" "$OWNER"
+        write_output "repo" "$REPO"
+        write_output "pr" "$PR"
+        write_output "repo-url" "$REPO_URL"
+        write_output "pr-title" "$PR_TITLE"
+        write_output "pr-author" "$PR_AUTHOR"
+        write_output "pr-labels" "$PR_LABELS"
+        write_output "pipeline-run-id" "$PIPELINE_RUN_ID"
+        write_output "mode" "$MODE"
+        write_output "pr-status" "$PR_STATUS"
 
     - name: Run scanner
       if: steps.context.outputs.mode == 'scan'
@@ -164,28 +210,39 @@ runs:
         INFRACOST_CLI_AUTHENTICATION_TOKEN: ${{ inputs.api-key }}
         INFRACOST_CLI_LOG_LEVEL: info
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_BASE_PATH: ${{ inputs.base-path }}
+        INPUT_HEAD_PATH: ${{ inputs.head-path }}
+        INPUT_PROJECT: ${{ inputs.project }}
+        CONTEXT_OWNER: ${{ steps.context.outputs.owner }}
+        CONTEXT_REPO: ${{ steps.context.outputs.repo }}
+        CONTEXT_PR: ${{ steps.context.outputs.pr }}
+        CONTEXT_REPO_URL: ${{ steps.context.outputs.repo-url }}
+        CONTEXT_PR_TITLE: ${{ steps.context.outputs.pr-title }}
+        CONTEXT_PR_AUTHOR: ${{ steps.context.outputs.pr-author }}
+        CONTEXT_PR_LABELS: ${{ steps.context.outputs.pr-labels }}
+        CONTEXT_PIPELINE_RUN_ID: ${{ steps.context.outputs.pipeline-run-id }}
       run: |
-        if [ -z "${{ inputs.base-path }}" ] || [ -z "${{ inputs.head-path }}" ]; then
+        if [ -z "$INPUT_BASE_PATH" ] || [ -z "$INPUT_HEAD_PATH" ]; then
           echo "::error::base-path and head-path are required for scanning."
           exit 1
         fi
 
         ARGS=(
           diff
-          --base-path "${{ inputs.base-path }}"
-          --head-path "${{ inputs.head-path }}"
-          --github-owner "${{ steps.context.outputs.owner }}"
-          --github-repo "${{ steps.context.outputs.repo }}"
-          --pr-number "${{ steps.context.outputs.pr }}"
-          --repo-url "${{ steps.context.outputs.repo-url }}"
-          --pr-title "${{ steps.context.outputs.pr-title }}"
-          --pr-author "${{ steps.context.outputs.pr-author }}"
-          --pr-labels "${{ steps.context.outputs.pr-labels }}"
-          --pipeline-run-id "${{ steps.context.outputs.pipeline-run-id }}"
+          --base-path "$INPUT_BASE_PATH"
+          --head-path "$INPUT_HEAD_PATH"
+          --github-owner "$CONTEXT_OWNER"
+          --github-repo "$CONTEXT_REPO"
+          --pr-number "$CONTEXT_PR"
+          --repo-url "$CONTEXT_REPO_URL"
+          --pr-title "$CONTEXT_PR_TITLE"
+          --pr-author "$CONTEXT_PR_AUTHOR"
+          --pr-labels "$CONTEXT_PR_LABELS"
+          --pipeline-run-id "$CONTEXT_PIPELINE_RUN_ID"
         )
 
-        if [ -n "${{ inputs.project }}" ]; then
-          ARGS+=(--project "${{ inputs.project }}")
+        if [ -n "$INPUT_PROJECT" ]; then
+          ARGS+=(--project "$INPUT_PROJECT")
         fi
 
         infracost-scanner "${ARGS[@]}"
@@ -196,8 +253,11 @@ runs:
       env:
         INFRACOST_CLI_AUTHENTICATION_TOKEN: ${{ inputs.api-key }}
         INFRACOST_CLI_LOG_LEVEL: info
+        CONTEXT_REPO_URL: ${{ steps.context.outputs.repo-url }}
+        CONTEXT_PR: ${{ steps.context.outputs.pr }}
+        CONTEXT_PR_STATUS: ${{ steps.context.outputs.pr-status }}
       run: |
         infracost-scanner status \
-          --repo-url "${{ steps.context.outputs.repo-url }}" \
-          --pr-number "${{ steps.context.outputs.pr }}" \
-          --status "${{ steps.context.outputs.pr-status }}"
+          --repo-url "$CONTEXT_REPO_URL" \
+          --pr-number "$CONTEXT_PR" \
+          --status "$CONTEXT_PR_STATUS"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,10 +30,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -57,9 +67,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,16 +6,332 @@
     "": {
       "name": "infracost-actions",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^8.0.1"
+      },
       "devDependencies": {
         "dotenv": "^16.4.5",
         "js-yaml": "^4.1.0"
       }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.0.tgz",
+      "integrity": "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.4.5",
@@ -28,6 +344,55 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.377",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.377.tgz",
+      "integrity": "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g==",
+      "license": "ISC"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.2.0",
@@ -51,20 +416,350 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     }
   },
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw=="
+    },
+    "@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "requires": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      }
+    },
+    "@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "requires": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "requires": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
+      }
+    },
+    "@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw=="
+    },
+    "@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA=="
+    },
+    "@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q=="
+    },
+    "@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "requires": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "requires": {
+        "@babel/types": "^8.0.0"
+      }
+    },
+    "@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "requires": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.0.tgz",
+      "integrity": "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==",
+      "requires": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "obug": "^2.1.1"
+      }
+    },
+    "@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "requires": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg=="
+    },
+    "@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="
+    },
+    "browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "requires": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="
+    },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
     "dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.5.377",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.377.tgz",
+      "integrity": "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g=="
+    },
+    "empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="
+    },
+    "escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+    },
+    "import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="
+    },
+    "js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
     },
     "js-yaml": {
       "version": "4.2.0",
@@ -73,6 +768,50 @@
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
+      }
+    },
+    "jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
+    "lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="
+    },
+    "node-releases": {
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA=="
+    },
+    "obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="
+    },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
+    },
+    "update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "requires": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "js-yaml": "^4.1.0"
   },
   "dependencies": {
+    "@babel/core": "^8.0.1"
   }
 }

--- a/scan/action.yml
+++ b/scan/action.yml
@@ -33,6 +33,19 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         VERSION: ${{ inputs.version }}
       run: |
+        write_output() {
+          local name="$1"
+          local value="$2"
+          local delimiter
+          delimiter="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}"
+
+          {
+            printf '%s<<%s\n' "$name" "$delimiter"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+        }
+
         if [ "$VERSION" = "latest" ]; then
           RELEASE=$(gh release list --repo "infracost/actions" --limit 50 --json tagName --jq '[.[] | select(.tagName | startswith("scanner/v"))][0].tagName')
           if [ -z "$RELEASE" ]; then
@@ -41,8 +54,8 @@ runs:
           fi
           VERSION="${RELEASE#scanner/v}"
         fi
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "tag=scanner/v${VERSION}" >> $GITHUB_OUTPUT
+        write_output "version" "$VERSION"
+        write_output "tag" "scanner/v${VERSION}"
 
     - name: Download scanner
       shell: bash
@@ -74,30 +87,48 @@ runs:
     - name: Derive context
       id: context
       shell: bash
+      env:
+        INPUT_REPO_URL: ${{ inputs.repo-url }}
       run: |
-        REPO_URL="${{ inputs.repo-url }}"
+        write_output() {
+          local name="$1"
+          local value="$2"
+          local delimiter
+          delimiter="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}_${RANDOM}"
+
+          {
+            printf '%s<<%s\n' "$name" "$delimiter"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+        }
+
+        REPO_URL="$INPUT_REPO_URL"
 
         if [ -z "$REPO_URL" ]; then
           REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
         fi
 
-        echo "repo-url=${REPO_URL}" >> $GITHUB_OUTPUT
+        write_output "repo-url" "$REPO_URL"
 
     - name: Run scanner
       shell: bash
       env:
         INFRACOST_CLI_AUTHENTICATION_TOKEN: ${{ inputs.api-key }}
         INFRACOST_CLI_LOG_LEVEL: info
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_PROJECT: ${{ inputs.project }}
+        CONTEXT_REPO_URL: ${{ steps.context.outputs.repo-url }}
       run: |
         ARGS=(
           scan
-          --path "${{ inputs.path }}"
-          --repo-url "${{ steps.context.outputs.repo-url }}"
+          --path "$INPUT_PATH"
+          --repo-url "$CONTEXT_REPO_URL"
           --pipeline-run-id "${GITHUB_RUN_ID}"
         )
 
-        if [ -n "${{ inputs.project }}" ]; then
-          ARGS+=(--project "${{ inputs.project }}")
+        if [ -n "$INPUT_PROJECT" ]; then
+          ARGS+=(--project "$INPUT_PROJECT")
         fi
 
         infracost-scanner "${ARGS[@]}"

--- a/testdata/tests/default.yml
+++ b/testdata/tests/default.yml
@@ -64,9 +64,12 @@ jobs:
       #   new - Create a new cost estimate comment on every push.
       # See https://www.infracost.io/docs/features/cli_commands/#comment-on-pull-requests for other options.
       - name: Post Infracost comment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
             infracost comment github --path=/tmp/infracost.json \
-                                     --repo=$GITHUB_REPOSITORY \
-                                     --github-token=${{ github.token }} \
-                                     --pull-request=${{ github.event.pull_request.number }} \
+                                     --repo="$GITHUB_REPOSITORY" \
+                                     --github-token="$GITHUB_TOKEN" \
+                                     --pull-request="$PULL_REQUEST_NUMBER" \
                                      --behavior=update


### PR DESCRIPTION
There is potential for a script injection when evaluating inputs inside a script. By passing the inputs through the env we can avoid this risk as it is data rather than an evaluateable command (as long as it remains within the ""

Update the immediate threat posed by the diff action, but took the opportunity to tidy up other places

Tested here: https://github.com/infracost/gh-actions-demo/pull/106/checks

