### PR TITLE
feat(dashboard): add SavePostedPrComment method [FIX-730]

### DIFF
--- a/tools/scanner/internal/api/dashboard/client.go
+++ b/tools/scanner/internal/api/dashboard/client.go
@@ -204,13 +204,13 @@ type BreakdownInput struct {
 
 // BudgetResultInput represents a budget evaluation result.
 type BudgetResultInput struct {
-	BudgetID             string              `json:"budgetId"`
-	Tags                 []BudgetTagInput    `json:"tags"`
-	StartDate            string              `json:"startDate"`
-	EndDate              string              `json:"endDate"`
-	Amount               string              `json:"amount"`
-	CurrentCost          string              `json:"currentCost"`
-	CustomOverrunMessage string              `json:"customOverrunMessage,omitempty"`
+	BudgetID             string           `json:"budgetId"`
+	Tags                 []BudgetTagInput `json:"tags"`
+	StartDate            string           `json:"startDate"`
+	EndDate              string           `json:"endDate"`
+	Amount               string           `json:"amount"`
+	CurrentCost          string           `json:"currentCost"`
+	CustomOverrunMessage string           `json:"customOverrunMessage,omitempty"`
 }
 
 // BudgetTagInput represents a budget tag key-value pair.
@@ -250,11 +250,10 @@ type Client interface {
 	RunParameters(ctx context.Context, repoURL, branchName string) (RunParameters, error)
 	AddRun(ctx context.Context, input RunInput) (AddRunResult, error)
 	UpdatePullRequestStatus(ctx context.Context, prURL string, status PullRequestStatus) error
+	SavePostedPrComment(ctx context.Context, runID, comment string) (bool, error)
 }
 
-var (
-	_ Client = (*client)(nil)
-)
+var _ Client = (*client)(nil)
 
 type client struct {
 	client *http.Client
@@ -363,4 +362,46 @@ func (c *client) UpdatePullRequestStatus(ctx context.Context, prURL string, stat
 		return errors.New(strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+func (c *client) SavePostedPrComment(ctx context.Context, runID, comment string) (bool, error) {
+	if runID == "" {
+		return false, errors.New("runID is required")
+	}
+	if comment == "" {
+		return false, errors.New("comment is required")
+	}
+
+	const query = `mutation SavePostedPrComment($runId: String!, $comment: String!) {
+  savePostedPrComment(runId: $runId, comment: $comment)
+}`
+
+	type response struct {
+		SavePostedPrComment *bool `json:"savePostedPrComment"`
+	}
+
+	variables := map[string]interface{}{
+		"runId":   runID,
+		"comment": comment,
+	}
+
+	r, err := graphql.Query[response](ctx, c.client, fmt.Sprintf("%s/graphql", c.config.Endpoint), query, variables)
+	if err != nil {
+		return false, err
+	}
+
+	if len(r.Errors) > 0 {
+		var errs []string
+		for _, e := range r.Errors {
+			errs = append(errs, e.Message)
+		}
+		return false, errors.New(strings.Join(errs, "; "))
+	}
+
+	// The HTTP status is not checked, so an absent field is the only signal that
+	// the body came from something other than the GraphQL API.
+	if r.Data.SavePostedPrComment == nil {
+		return false, errors.New("savePostedPrComment missing from response")
+	}
+	return *r.Data.SavePostedPrComment, nil
 }

--- a/tools/scanner/internal/api/dashboard/client_test.go
+++ b/tools/scanner/internal/api/dashboard/client_test.go
@@ -1,0 +1,163 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSavePostedPrComment(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		response   string
+		wantSaved  bool
+		wantErrMsg string
+	}{
+		{
+			name:      "saved",
+			status:    http.StatusOK,
+			response:  `{"data":{"savePostedPrComment":true}}`,
+			wantSaved: true,
+		},
+		{
+			name:     "not saved",
+			status:   http.StatusOK,
+			response: `{"data":{"savePostedPrComment":false}}`,
+		},
+		{
+			name:       "graphql errors",
+			status:     http.StatusOK,
+			response:   `{"errors":[{"message":"run not found"},{"message":"forbidden"}]}`,
+			wantErrMsg: "run not found; forbidden",
+		},
+		{
+			name:       "missing field",
+			status:     http.StatusOK,
+			response:   `{"data":{}}`,
+			wantErrMsg: "savePostedPrComment missing from response",
+		},
+		{
+			name:       "null data",
+			status:     http.StatusOK,
+			response:   `{"data":null}`,
+			wantErrMsg: "savePostedPrComment missing from response",
+		},
+		{
+			name:       "gateway error",
+			status:     http.StatusBadGateway,
+			response:   `{"message":"Internal server error"}`,
+			wantErrMsg: "savePostedPrComment missing from response",
+		},
+		{
+			name:       "forbidden",
+			status:     http.StatusForbidden,
+			response:   `{"message":"forbidden"}`,
+			wantErrMsg: "savePostedPrComment missing from response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/graphql", r.URL.Path)
+
+				body, err := io.ReadAll(r.Body)
+				if !assert.NoError(t, err) {
+					return
+				}
+
+				var request struct {
+					Query     string            `json:"query"`
+					Variables map[string]string `json:"variables"`
+				}
+				if !assert.NoError(t, json.Unmarshal(body, &request)) {
+					return
+				}
+
+				assert.Contains(t, request.Query, "mutation SavePostedPrComment($runId: String!, $comment: String!)")
+				assert.Contains(t, request.Query, "savePostedPrComment(runId: $runId, comment: $comment)")
+				assert.Equal(t, map[string]string{"runId": "test-run-id", "comment": "comment body"}, request.Variables)
+
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			c := newTestClient(server.URL)
+
+			saved, err := c.SavePostedPrComment(context.Background(), "test-run-id", "comment body")
+
+			if tt.wantErrMsg != "" {
+				require.EqualError(t, err, tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantSaved, saved)
+		})
+	}
+}
+
+func TestSavePostedPrCommentValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		runID      string
+		comment    string
+		wantErrMsg string
+	}{
+		{
+			name:       "empty run id",
+			comment:    "comment body",
+			wantErrMsg: "runID is required",
+		},
+		{
+			name:       "empty comment",
+			runID:      "test-run-id",
+			wantErrMsg: "comment is required",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		assert.Fail(t, "unexpected request to the dashboard")
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saved, err := c.SavePostedPrComment(context.Background(), tt.runID, tt.comment)
+			require.EqualError(t, err, tt.wantErrMsg)
+			assert.False(t, saved)
+		})
+	}
+}
+
+func TestSavePostedPrCommentTransportError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if !assert.NoError(t, err) {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	c := newTestClient(server.URL)
+
+	saved, err := c.SavePostedPrComment(context.Background(), "test-run-id", "comment body")
+	require.Error(t, err)
+	assert.False(t, saved)
+}
+
+func newTestClient(endpoint string) Client {
+	cfg := &Config{Endpoint: endpoint}
+	cfg.Process()
+	return cfg.Client(http.DefaultClient)
+}

--- a/tools/scanner/internal/api/dashboard/mocks/mocks.go
+++ b/tools/scanner/internal/api/dashboard/mocks/mocks.go
@@ -176,6 +176,78 @@ func (_c *MockClient_RunParameters_Call) RunAndReturn(run func(ctx context.Conte
 	return _c
 }
 
+// SavePostedPrComment provides a mock function for the type MockClient
+func (_mock *MockClient) SavePostedPrComment(ctx context.Context, runID string, comment string) (bool, error) {
+	ret := _mock.Called(ctx, runID, comment)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SavePostedPrComment")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, runID, comment)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, runID, comment)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, runID, comment)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockClient_SavePostedPrComment_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SavePostedPrComment'
+type MockClient_SavePostedPrComment_Call struct {
+	*mock.Call
+}
+
+// SavePostedPrComment is a helper method to define mock.On call
+//   - ctx context.Context
+//   - runID string
+//   - comment string
+func (_e *MockClient_Expecter) SavePostedPrComment(ctx any, runID any, comment any) *MockClient_SavePostedPrComment_Call {
+	return &MockClient_SavePostedPrComment_Call{Call: _e.mock.On("SavePostedPrComment", ctx, runID, comment)}
+}
+
+func (_c *MockClient_SavePostedPrComment_Call) Run(run func(ctx context.Context, runID string, comment string)) *MockClient_SavePostedPrComment_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_SavePostedPrComment_Call) Return(b bool, err error) *MockClient_SavePostedPrComment_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockClient_SavePostedPrComment_Call) RunAndReturn(run func(ctx context.Context, runID string, comment string) (bool, error)) *MockClient_SavePostedPrComment_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdatePullRequestStatus provides a mock function for the type MockClient
 func (_mock *MockClient) UpdatePullRequestStatus(ctx context.Context, prURL string, status dashboard.PullRequestStatus) error {
 	ret := _mock.Called(ctx, prURL, status)


### PR DESCRIPTION
Adds `SavePostedPrComment(runID, comment)` to the scanner's dashboard client, so a run's posted comment can be recorded after `addRun` has already been sent.

Today the scanner declares `clientPostedComment: true` up front and never sends the body, so `runs.posted_comment` stays null for every scanner run — and cost prevention counts a run only when that column holds a body.

The mutation already exists dashboard-side, behind the same `runsWrite` scope as `addRun`. It is write-once and atomic:

- `(true, nil)` — the body was stored.
- `(false, nil)` — the run already has a comment. Expected on a retry, not an error.
- `(_, err)` — transport or GraphQL failure only.

### Non-breaking

Nothing calls the method yet:

- `diff`, `scan` and `status` are unchanged, so no new request goes out at runtime.
- `internal/api/dashboard` is an internal package of the `tools/scanner` module, so no external code can implement `Client`. The only implementations are `*client` and the generated `MockClient`, both updated here.
- No schema, config or credential change.

The call site — pessimistic `clientPostedComment: false`, a non-fatal upload, and saving the body from the real `PostResult` — lands in FIX-736, which asks to keep the reorder and the flag as one change. Until then this merges as unused code.

Includes client tests and regenerated mocks.
