### PR TITLE
feat(scanner): support multiple VCS providers for pull request URLs [FIX-718]

### DIFF
--- a/diff/action.yml
+++ b/diff/action.yml
@@ -209,6 +209,7 @@ runs:
       env:
         INFRACOST_CLI_AUTHENTICATION_TOKEN: ${{ inputs.api-key }}
         INFRACOST_CLI_LOG_LEVEL: info
+        # Must match the Update PR status step: both key on the same PR URL.
         INFRACOST_VCS_PROVIDER: github
         GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_BASE_PATH: ${{ inputs.base-path }}
@@ -254,6 +255,7 @@ runs:
       env:
         INFRACOST_CLI_AUTHENTICATION_TOKEN: ${{ inputs.api-key }}
         INFRACOST_CLI_LOG_LEVEL: info
+        INFRACOST_VCS_PROVIDER: github
         CONTEXT_REPO_URL: ${{ steps.context.outputs.repo-url }}
         CONTEXT_PR: ${{ steps.context.outputs.pr }}
         CONTEXT_PR_STATUS: ${{ steps.context.outputs.pr-status }}

--- a/tools/scanner/internal/api/dashboard/mocks/mocks.go
+++ b/tools/scanner/internal/api/dashboard/mocks/mocks.go
@@ -17,10 +17,19 @@ func NewMockClient(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockClient {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockClient{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/tools/scanner/internal/api/events/mocks/mocks.go
+++ b/tools/scanner/internal/api/events/mocks/mocks.go
@@ -16,10 +16,19 @@ func NewMockClient(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockClient {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockClient{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/tools/scanner/internal/commands/diff.go
+++ b/tools/scanner/internal/commands/diff.go
@@ -9,6 +9,7 @@ import (
 	"github.com/infracost/actions/tools/scanner/internal/api"
 	"github.com/infracost/actions/tools/scanner/internal/config"
 	"github.com/infracost/actions/tools/scanner/internal/git"
+	"github.com/infracost/actions/tools/scanner/internal/vcsurl"
 	"github.com/infracost/go-proto/pkg/diagnostic"
 	pkgscanner "github.com/infracost/cli/pkg/scanner"
 	"github.com/infracost/proto/gen/go/infracost/parser/event"
@@ -85,7 +86,7 @@ func Diff(cfg *config.Config, results *ScanResult) *cobra.Command {
 
 func newVCSClient(ctx context.Context, provider string, args *diffArgs) (vcs.VCS, error) {
 	switch provider {
-	case "github":
+	case vcsurl.ProviderGitHub:
 		return github.New(ctx, args.githubOwner, args.githubRepo, args.githubToken, int32(args.prNumber), github.Options{}) //nolint:gosec // PR numbers won't overflow int32
 	default:
 		return nil, fmt.Errorf("posting comments is only supported on github, not %q", provider)
@@ -99,6 +100,16 @@ func diff(cfg *config.Config, args *diffArgs, vcsClient vcs.VCS, results *ScanRe
 	vcsProvider, err := resolveVCSProvider(cfg)
 	if err != nil {
 		return err
+	}
+
+	// Fail before scanning: diff is always a pull request run, so a missing or
+	// unbuildable PR URL would upload as a branch run and lose the PR.
+	prURL, err := vcsurl.PullRequest(vcsProvider, args.repoURL, args.prNumber)
+	if err != nil {
+		return err
+	}
+	if prURL == "" {
+		return fmt.Errorf("cannot determine the pull request URL: --repo-url and --pr-number are required")
 	}
 
 	headCommitSHA := git.RevParse(args.headPath, "HEAD")

--- a/tools/scanner/internal/commands/diff_test.go
+++ b/tools/scanner/internal/commands/diff_test.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/infracost/actions/tools/scanner/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// diff is always a pull request run, so it must refuse to scan rather than
+// upload a run the dashboard would file as a branch build.
+func TestDiff_RequiresBuildablePullRequestURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		repoURL  string
+		prNumber int
+		wantErr  string
+	}{
+		{
+			name:     "missing repo url",
+			provider: "github",
+			prNumber: 42,
+			wantErr:  "cannot determine the pull request URL: --repo-url and --pr-number are required",
+		},
+		{
+			name:     "zero pr number",
+			provider: "github",
+			repoURL:  "https://github.com/infracost/actions",
+			wantErr:  "cannot determine the pull request URL: --repo-url and --pr-number are required",
+		},
+		{
+			name:     "ssh clone url",
+			provider: "gitlab",
+			repoURL:  "git@gitlab.com:infracost/actions.git",
+			prNumber: 42,
+			wantErr:  `repo URL "git@gitlab.com:infracost/actions.git" must be an http(s) web URL of the repository, not a clone URL`,
+		},
+		{
+			name:     "azure project url without _git",
+			provider: "azure_repos",
+			repoURL:  "https://dev.azure.com/infracost/actions",
+			prNumber: 42,
+			wantErr:  `repo URL "https://dev.azure.com/infracost/actions" must be an Azure Repos repository URL containing /_git/`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{VCSProvider: tt.provider}
+			args := &diffArgs{repoURL: tt.repoURL, prNumber: tt.prNumber}
+
+			err := diff(cfg, args, nil, &ScanResult{})
+
+			require.Error(t, err)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}

--- a/tools/scanner/internal/commands/metadata.go
+++ b/tools/scanner/internal/commands/metadata.go
@@ -3,17 +3,13 @@ package commands
 import (
 	"fmt"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/infracost/actions/tools/scanner/internal/api/events"
 	"github.com/infracost/actions/tools/scanner/internal/config"
+	"github.com/infracost/actions/tools/scanner/internal/vcsurl"
 )
-
-// vcsProviders is the accepted value set. The dashboard writes the provider
-// when it creates the repo and never rewrites it, so a typo would stick.
-var vcsProviders = []string{"github", "gitlab", "azure_repos", "bitbucket"}
 
 // ciPlatform passes an explicit INFRACOST_CI_PLATFORM through verbatim;
 // normalising it would discard a boolean-ish name chosen on purpose.
@@ -49,13 +45,13 @@ func normalizeCIPlatform(raw string) string {
 func resolveVCSProvider(cfg *config.Config) (string, error) {
 	if cfg.VCSProvider != "" {
 		provider := strings.ToLower(strings.TrimSpace(cfg.VCSProvider))
-		if !slices.Contains(vcsProviders, provider) {
-			return "", fmt.Errorf("unrecognised VCS provider %q: set INFRACOST_VCS_PROVIDER to %s", cfg.VCSProvider, strings.Join(vcsProviders, ", "))
+		if !vcsurl.Valid(provider) {
+			return "", fmt.Errorf("unrecognised VCS provider %q: set INFRACOST_VCS_PROVIDER to %s", cfg.VCSProvider, vcsurl.ProviderList())
 		}
 		return provider, nil
 	}
 	if os.Getenv("GITHUB_ACTIONS") != "" {
-		return "github", nil
+		return vcsurl.ProviderGitHub, nil
 	}
-	return "", fmt.Errorf("cannot determine the VCS provider: set INFRACOST_VCS_PROVIDER to %s", strings.Join(vcsProviders, ", "))
+	return "", fmt.Errorf("cannot determine the VCS provider: set INFRACOST_VCS_PROVIDER to %s", vcsurl.ProviderList())
 }

--- a/tools/scanner/internal/commands/metadata_test.go
+++ b/tools/scanner/internal/commands/metadata_test.go
@@ -52,6 +52,8 @@ func TestResolveVCSProvider(t *testing.T) {
 		{name: "configured without github actions", configured: "bitbucket", expected: "bitbucket"},
 		{name: "case and whitespace folded", configured: " Github ", expected: "github"},
 		{name: "typo rejected", configured: "githbu", githubActions: "true", expectErr: true},
+		{name: "vcs module package name rejected", configured: "azure", expectErr: true},
+		{name: "ci platform name rejected", configured: "gitlab_ci", expectErr: true},
 		{name: "unset falls back on github actions", githubActions: "true", expected: "github"},
 		{name: "unset elsewhere errors", expectErr: true},
 	}

--- a/tools/scanner/internal/commands/status.go
+++ b/tools/scanner/internal/commands/status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/infracost/actions/tools/scanner/internal/api"
 	"github.com/infracost/actions/tools/scanner/internal/api/dashboard"
 	"github.com/infracost/actions/tools/scanner/internal/config"
+	"github.com/infracost/actions/tools/scanner/internal/vcsurl"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,11 @@ func Status(cfg *config.Config) *cobra.Command {
 			default:
 				return fmt.Errorf("invalid status %q: must be OPEN, MERGED, or CLOSED", status)
 			}
-			return updatePullRequestStatus(cfg, args.repoURL, args.prNumber, status)
+			provider, err := resolveVCSProvider(cfg)
+			if err != nil {
+				return err
+			}
+			return updatePullRequestStatus(cfg, provider, args.repoURL, args.prNumber, status)
 		},
 	}
 
@@ -43,11 +48,14 @@ func Status(cfg *config.Config) *cobra.Command {
 	return statusCmd
 }
 
-func updatePullRequestStatus(cfg *config.Config, repoURL string, prNumber int, status dashboard.PullRequestStatus) error {
-	if repoURL == "" || prNumber == 0 {
+func updatePullRequestStatus(cfg *config.Config, provider, repoURL string, prNumber int, status dashboard.PullRequestStatus) error {
+	prURL, err := vcsurl.PullRequest(provider, repoURL, prNumber)
+	if err != nil {
+		return err
+	}
+	if prURL == "" {
 		return fmt.Errorf("cannot determine pull request URL: repo-url and pr-number are required")
 	}
-	prURL := fmt.Sprintf("%s/pull/%d", repoURL, prNumber)
 
 	ctx := context.Background()
 	if len(cfg.Auth.AuthenticationToken) == 0 {

--- a/tools/scanner/internal/config/config_test.go
+++ b/tools/scanner/internal/config/config_test.go
@@ -20,3 +20,33 @@ func TestConfig_Process(t *testing.T) {
 	require.NoError(t, flags.Parse(nil)) // we have no required flags yet, so will provide nothing
 	process.Process(&cfg)                // make sure doesn't panic
 }
+
+// The action's status step passes the provider by environment variable only,
+// so the env tag is the whole contract.
+func TestConfig_VCSProviderFromEnv(t *testing.T) {
+	t.Setenv("INFRACOST_VCS_PROVIDER", "gitlab")
+
+	var cfg Config
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	if diags := process.PreProcess(&cfg, flags); diags.Len() != 0 {
+		t.Fatal(diags)
+	}
+	require.NoError(t, flags.Parse(nil))
+	process.Process(&cfg)
+
+	require.Equal(t, "gitlab", cfg.VCSProvider)
+}
+
+func TestConfig_VCSProviderFlagOverridesEnv(t *testing.T) {
+	t.Setenv("INFRACOST_VCS_PROVIDER", "gitlab")
+
+	var cfg Config
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	if diags := process.PreProcess(&cfg, flags); diags.Len() != 0 {
+		t.Fatal(diags)
+	}
+	require.NoError(t, flags.Parse([]string{"--vcs-provider", "bitbucket"}))
+	process.Process(&cfg)
+
+	require.Equal(t, "bitbucket", cfg.VCSProvider)
+}

--- a/tools/scanner/internal/config/run.go
+++ b/tools/scanner/internal/config/run.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/infracost/actions/tools/scanner/internal/api/dashboard"
+	"github.com/infracost/actions/tools/scanner/internal/vcsurl"
 	"github.com/infracost/actions/tools/scanner/internal/version"
 	pkgscanner "github.com/infracost/cli/pkg/scanner"
 	"github.com/infracost/go-proto/pkg/address"
@@ -191,10 +192,11 @@ func BuildRunInput(opts RunInputOptions) dashboard.RunInput {
 }
 
 func buildRunInputFromMetadata(opts RunInputOptions, projectResults []dashboard.ProjectResultInput) dashboard.RunInput {
-	var prURL string
+	// Dropped to keep BuildRunInput pure. Of its two callers, diff rejects an
+	// unbuildable URL before scanning and scan never sets PRNumber.
+	prURL, _ := vcsurl.PullRequest(opts.VCSProvider, opts.RepoURL, opts.PRNumber)
 	var prID string
-	if opts.PRNumber > 0 && opts.RepoURL != "" {
-		prURL = fmt.Sprintf("%s/pull/%d", opts.RepoURL, opts.PRNumber)
+	if prURL != "" {
 		prID = fmt.Sprintf("%d", opts.PRNumber)
 	}
 

--- a/tools/scanner/internal/config/run_test.go
+++ b/tools/scanner/internal/config/run_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildRunInput_Metadata_CIPlatformAndVCSProvider(t *testing.T) {
@@ -51,4 +52,89 @@ func TestBuildErrorRunInput_Metadata_CIPlatformAndVCSProvider(t *testing.T) {
 
 	assert.Equal(t, "gitlab_ci", input.Metadata["ciPlatform"])
 	assert.Equal(t, "gitlab", input.Metadata["vcsProvider"])
+}
+
+func TestBuildRunInput_PullRequestURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		repoURL  string
+		prNumber int
+		wantURL  string
+		wantID   string
+	}{
+		{
+			name:     "github",
+			provider: "github",
+			repoURL:  "https://github.com/infracost/actions",
+			prNumber: 42,
+			wantURL:  "https://github.com/infracost/actions/pull/42",
+			wantID:   "42",
+		},
+		{
+			name:     "gitlab",
+			provider: "gitlab",
+			repoURL:  "https://gitlab.com/infracost/actions",
+			prNumber: 42,
+			wantURL:  "https://gitlab.com/infracost/actions/-/merge_requests/42",
+			wantID:   "42",
+		},
+		{
+			name:     "azure repos",
+			provider: "azure_repos",
+			repoURL:  "https://dev.azure.com/infracost/actions/_git/actions",
+			prNumber: 42,
+			wantURL:  "https://dev.azure.com/infracost/actions/_git/actions/pullrequest/42",
+			wantID:   "42",
+		},
+		{
+			name:     "bitbucket",
+			provider: "bitbucket",
+			repoURL:  "https://bitbucket.org/infracost/actions",
+			prNumber: 42,
+			wantURL:  "https://bitbucket.org/infracost/actions/pull-requests/42",
+			wantID:   "42",
+		},
+		{
+			name:     "branch run has no pull request",
+			provider: "gitlab",
+			repoURL:  "https://gitlab.com/infracost/actions",
+			prNumber: 0,
+		},
+		{
+			name:     "unbuildable url yields no pull request",
+			provider: "gitlab",
+			repoURL:  "git@gitlab.com:infracost/actions.git",
+			prNumber: 42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := BuildRunInput(RunInputOptions{
+				Command:     "comment",
+				VCSProvider: tt.provider,
+				RepoURL:     tt.repoURL,
+				PRNumber:    tt.prNumber,
+			})
+
+			assertMetadata(t, input.Metadata, "vcsPullRequestUrl", tt.wantURL)
+			assertMetadata(t, input.Metadata, "vcsPullRequestId", tt.wantID)
+
+			repoMeta, ok := input.Metadata["repoMetadata"].(map[string]any)
+			require.True(t, ok, "repoMetadata should be an object")
+			assertMetadata(t, repoMeta, "vcsPullRequestUrl", tt.wantURL)
+		})
+	}
+}
+
+// assertMetadata treats an absent key as empty: the PR fields are omitempty.
+func assertMetadata(t *testing.T, metadata map[string]any, key, want string) {
+	t.Helper()
+
+	if want == "" {
+		assert.Empty(t, metadata[key], key)
+		return
+	}
+	assert.Equal(t, want, metadata[key], key)
 }

--- a/tools/scanner/internal/mocks/vcs/mocks.go
+++ b/tools/scanner/internal/mocks/vcs/mocks.go
@@ -18,10 +18,19 @@ func NewMockVCS(t interface {
 	mock.TestingT
 	Cleanup(func())
 }) *MockVCS {
+	if helper, ok := t.(interface{ Helper() }); ok {
+		helper.Helper()
+	}
+
 	mock := &MockVCS{}
 	mock.Mock.Test(t)
 
-	t.Cleanup(func() { mock.AssertExpectations(t) })
+	t.Cleanup(func() {
+		if helper, ok := t.(interface{ Helper() }); ok {
+			helper.Helper()
+		}
+		mock.AssertExpectations(t)
+	})
 
 	return mock
 }

--- a/tools/scanner/internal/vcsurl/pullrequest.go
+++ b/tools/scanner/internal/vcsurl/pullrequest.go
@@ -1,0 +1,92 @@
+// Package vcsurl builds VCS web URLs from a repository's web URL.
+package vcsurl
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// Provider names. Fixed by the v0.1 INFRACOST_VCS_PROVIDER contract, and
+// deliberately not the vcs module's package names.
+const (
+	ProviderGitHub     = "github"
+	ProviderGitLab     = "gitlab"
+	ProviderAzureRepos = "azure_repos"
+	ProviderBitbucket  = "bitbucket"
+)
+
+// providers is the accepted value set, in the order error messages list them.
+// Unexported so no caller can widen the contract at runtime.
+var providers = []string{ProviderGitHub, ProviderGitLab, ProviderAzureRepos, ProviderBitbucket}
+
+// Valid reports whether PullRequest can build a URL for provider.
+func Valid(provider string) bool {
+	return slices.Contains(providers, provider)
+}
+
+// ProviderList renders the accepted providers for use in an error message.
+func ProviderList() string {
+	return strings.Join(providers, ", ")
+}
+
+// PullRequest returns the web URL of a pull request for the given provider.
+// repoURL is the repository's web URL. An empty repoURL or a number <= 0 yields
+// "" and no error, so a caller needing a PR URL must reject "" itself.
+func PullRequest(provider, repoURL string, number int) (string, error) {
+	if repoURL == "" || number <= 0 {
+		return "", nil
+	}
+
+	if err := checkWebURL(repoURL); err != nil {
+		return "", err
+	}
+	base := strings.TrimSuffix(strings.TrimSuffix(repoURL, "/"), ".git")
+
+	switch provider {
+	case ProviderGitHub:
+		return fmt.Sprintf("%s/pull/%d", base, number), nil
+	case ProviderGitLab:
+		// number must be the project-scoped iid, not the global merge request
+		// id. A global id is still positive, so it 404s silently.
+		return fmt.Sprintf("%s/-/merge_requests/%d", base, number), nil
+	case ProviderAzureRepos:
+		// Azure PR URLs hang off the repository, not the project, and a project
+		// URL is otherwise indistinguishable from a repository one.
+		if !strings.Contains(base, "/_git/") {
+			return "", fmt.Errorf("repo URL %q must be an Azure Repos repository URL containing /_git/", repoURL)
+		}
+		return fmt.Sprintf("%s/pullrequest/%d", base, number), nil
+	case ProviderBitbucket:
+		return fmt.Sprintf("%s/pull-requests/%d", base, number), nil
+	default:
+		return "", fmt.Errorf("cannot build a pull request URL for VCS provider %q: must be one of %s", provider, ProviderList())
+	}
+}
+
+// checkWebURL constrains the metadata URL, not the transport: nothing in the
+// binary clones, so an SSH remote here only yields an unopenable link.
+func checkWebURL(repoURL string) error {
+	u, err := url.Parse(repoURL)
+
+	// Checked before any error that echoes repoURL: a credentialed clone URL
+	// would otherwise leak its token into the error, metadata and PR key.
+	if err == nil && u.User != nil {
+		if _, set := u.User.Password(); set {
+			return fmt.Errorf("repo URL must not contain a password: pass the repository's web URL, not a credentialed clone URL")
+		}
+	}
+
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("repo URL %q must be an http(s) web URL of the repository, not a clone URL", repoURL)
+	}
+
+	// The PR path is appended to the raw URL, so anything after it corrupts.
+	// Not echoed: a query or fragment is a common place for a stray token.
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("repo URL must not contain a query or fragment: pass the repository's web URL")
+	}
+
+	return nil
+}

--- a/tools/scanner/internal/vcsurl/pullrequest_test.go
+++ b/tools/scanner/internal/vcsurl/pullrequest_test.go
@@ -1,0 +1,242 @@
+package vcsurl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPullRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		repoURL  string
+		number   int
+		want     string
+	}{
+		{
+			name:     "github",
+			provider: ProviderGitHub,
+			repoURL:  "https://github.com/infracost/actions",
+			number:   42,
+			want:     "https://github.com/infracost/actions/pull/42",
+		},
+		{
+			name:     "gitlab",
+			provider: ProviderGitLab,
+			repoURL:  "https://gitlab.com/infracost/actions",
+			number:   42,
+			want:     "https://gitlab.com/infracost/actions/-/merge_requests/42",
+		},
+		{
+			name:     "azure repos",
+			provider: ProviderAzureRepos,
+			repoURL:  "https://dev.azure.com/infracost/actions/_git/actions",
+			number:   42,
+			want:     "https://dev.azure.com/infracost/actions/_git/actions/pullrequest/42",
+		},
+		{
+			name:     "bitbucket",
+			provider: ProviderBitbucket,
+			repoURL:  "https://bitbucket.org/infracost/actions",
+			number:   42,
+			want:     "https://bitbucket.org/infracost/actions/pull-requests/42",
+		},
+		{
+			name:     "trims .git suffix",
+			provider: ProviderGitHub,
+			repoURL:  "https://github.com/infracost/actions.git",
+			number:   7,
+			want:     "https://github.com/infracost/actions/pull/7",
+		},
+		{
+			name:     "trims trailing slash",
+			provider: ProviderGitLab,
+			repoURL:  "https://gitlab.com/infracost/actions/",
+			number:   7,
+			want:     "https://gitlab.com/infracost/actions/-/merge_requests/7",
+		},
+		{
+			name:     "trims trailing slash then .git",
+			provider: ProviderGitHub,
+			repoURL:  "https://github.com/infracost/actions.git/",
+			number:   7,
+			want:     "https://github.com/infracost/actions/pull/7",
+		},
+		{
+			name:     "gitlab subgroup",
+			provider: ProviderGitLab,
+			repoURL:  "https://gitlab.com/infracost/team/platform/actions",
+			number:   3,
+			want:     "https://gitlab.com/infracost/team/platform/actions/-/merge_requests/3",
+		},
+		{
+			name:     "gitlab self-managed under a relative url root",
+			provider: ProviderGitLab,
+			repoURL:  "https://git.example.com/gitlab/infracost/actions",
+			number:   3,
+			want:     "https://git.example.com/gitlab/infracost/actions/-/merge_requests/3",
+		},
+		{
+			name:     "github enterprise server",
+			provider: ProviderGitHub,
+			repoURL:  "https://github.example.com/infracost/actions",
+			number:   3,
+			want:     "https://github.example.com/infracost/actions/pull/3",
+		},
+		{
+			name:     "azure visualstudio.com collection",
+			provider: ProviderAzureRepos,
+			repoURL:  "https://fabrikam.visualstudio.com/DefaultCollection/_git/Fabrikam",
+			number:   1,
+			want:     "https://fabrikam.visualstudio.com/DefaultCollection/_git/Fabrikam/pullrequest/1",
+		},
+		{
+			// sanitizeUrl strips userinfo server-side, so both scanner sites
+			// agree either way. Stripping in one of them is how they drift.
+			name:     "azure userinfo is passed through untouched",
+			provider: ProviderAzureRepos,
+			repoURL:  "https://infracost@dev.azure.com/infracost/actions/_git/actions",
+			number:   1,
+			want:     "https://infracost@dev.azure.com/infracost/actions/_git/actions/pullrequest/1",
+		},
+		{
+			name:     "http scheme",
+			provider: ProviderGitHub,
+			repoURL:  "http://github.example.com/infracost/actions",
+			number:   9,
+			want:     "http://github.example.com/infracost/actions/pull/9",
+		},
+		{
+			name:     "no pr number",
+			provider: ProviderGitHub,
+			repoURL:  "https://github.com/infracost/actions",
+			number:   0,
+			want:     "",
+		},
+		{
+			name:     "negative pr number",
+			provider: ProviderGitHub,
+			repoURL:  "https://github.com/infracost/actions",
+			number:   -1,
+			want:     "",
+		},
+		{
+			name:     "empty repo url",
+			provider: ProviderGitHub,
+			repoURL:  "",
+			number:   42,
+			want:     "",
+		},
+		{
+			name:     "empty repo url wins over an unknown provider",
+			provider: "not-a-provider",
+			repoURL:  "",
+			number:   42,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PullRequest(tt.provider, tt.repoURL, tt.number)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPullRequest_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    string
+		repoURL     string
+		wantMessage string
+	}{
+		{
+			name:        "unknown provider",
+			provider:    "not-a-provider",
+			repoURL:     "https://github.com/infracost/actions",
+			wantMessage: `cannot build a pull request URL for VCS provider "not-a-provider": must be one of github, gitlab, azure_repos, bitbucket`,
+		},
+		{
+			name:        "empty provider",
+			provider:    "",
+			repoURL:     "https://github.com/infracost/actions",
+			wantMessage: `cannot build a pull request URL for VCS provider "": must be one of github, gitlab, azure_repos, bitbucket`,
+		},
+		{
+			name:        "scp-style ssh remote",
+			provider:    ProviderGitHub,
+			repoURL:     "git@github.com:infracost/actions.git",
+			wantMessage: `repo URL "git@github.com:infracost/actions.git" must be an http(s) web URL of the repository, not a clone URL`,
+		},
+		{
+			name:        "ssh scheme remote",
+			provider:    ProviderGitHub,
+			repoURL:     "ssh://git@github.com/infracost/actions.git",
+			wantMessage: `repo URL "ssh://git@github.com/infracost/actions.git" must be an http(s) web URL of the repository, not a clone URL`,
+		},
+		{
+			name:        "no scheme",
+			provider:    ProviderGitHub,
+			repoURL:     "github.com/infracost/actions",
+			wantMessage: `repo URL "github.com/infracost/actions" must be an http(s) web URL of the repository, not a clone URL`,
+		},
+		{
+			name:        "no host",
+			provider:    ProviderGitLab,
+			repoURL:     "https:///infracost/actions",
+			wantMessage: `repo URL "https:///infracost/actions" must be an http(s) web URL of the repository, not a clone URL`,
+		},
+		{
+			name:        "empty host and path",
+			provider:    ProviderGitHub,
+			repoURL:     "https://",
+			wantMessage: `repo URL "https://" must be an http(s) web URL of the repository, not a clone URL`,
+		},
+		{
+			// The message must not echo the URL, or the token lands in the log.
+			name:        "gitlab job token in the userinfo",
+			provider:    ProviderGitLab,
+			repoURL:     "https://gitlab-ci-token:secret-token@gitlab.com/infracost/actions.git",
+			wantMessage: "repo URL must not contain a password: pass the repository's web URL, not a credentialed clone URL",
+		},
+		{
+			name:        "credentialed url with no host",
+			provider:    ProviderGitHub,
+			repoURL:     "https://user:secret-token@",
+			wantMessage: "repo URL must not contain a password: pass the repository's web URL, not a credentialed clone URL",
+		},
+		{
+			name:        "fragment",
+			provider:    ProviderGitHub,
+			repoURL:     "https://github.com/infracost/actions#frag",
+			wantMessage: `repo URL must not contain a query or fragment: pass the repository's web URL`,
+		},
+		{
+			name:        "query",
+			provider:    ProviderGitHub,
+			repoURL:     "https://github.com/infracost/actions?x=1",
+			wantMessage: `repo URL must not contain a query or fragment: pass the repository's web URL`,
+		},
+		{
+			name:        "azure project url without a repository",
+			provider:    ProviderAzureRepos,
+			repoURL:     "https://dev.azure.com/infracost/actions",
+			wantMessage: `repo URL "https://dev.azure.com/infracost/actions" must be an Azure Repos repository URL containing /_git/`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PullRequest(tt.provider, tt.repoURL, 42)
+			require.Error(t, err)
+			assert.Empty(t, got)
+			if tt.wantMessage != "" {
+				assert.EqualError(t, err, tt.wantMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The scanner was hardcoded to support only GitHub PR URLs, preventing it from working with other VCS providers like GitLab or Bitbucket.

This PR adds a new `vcsurl` package that builds provider-specific pull request URLs, replacing hardcoded GitHub assumptions. The VCS provider is resolved early—the diff command now fails immediately before scanning if the PR URL cannot be built, preventing silent failures on branch-run uploads. The provider is configured via the `INFRACOST_VCS_PROVIDER` environment variable or defaults to GitHub when `GITHUB_ACTIONS` is set, maintaining backward compatibility with pinned actions.
